### PR TITLE
added optional parameter to provide a secret when unlocking a vehicle

### DIFF
--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -93,7 +93,7 @@ class RemoteServices:
 
         A state update is triggered after this, as the lock state of the vehicle changes.
 
-        :arg unlock_secret: in some countries you can/must configure a BMW account security question to be able to
+        :arg unlock_secret: in some countries you can/must configure a BMW account security question to be able to \
         remotely unlock you vehicle. Use this parameter if you need to give such a unlock secret.
         """
         _LOGGER.debug('Triggering remote door lock')
@@ -130,7 +130,8 @@ class RemoteServices:
         """Trigger a generic remote service.
 
         :arg post: You can choose if you want a POST or a GET operation.
-        :arg unlock_secret: in some countries you can/must configure a BMW account security question to be able to
+
+        :arg unlock_secret: in some countries you can/must configure a BMW account security question to be able to \
         remotely unlock you vehicle. Use this parameter if you need to give such a unlock secret.
         """
 


### PR DESCRIPTION
Based on the feedback on #77 I added an optional parameter to `RemoteServices.trigger_remote_door_unlock`.

For easier testing I also added two new commands:
```
bimmerconnected unlock <user> <password> <region> <VIN> <secret>
bimmerconnected lock <user> <password> <region> <VIN>
```

The "secret" parameter is optional on the command line as well as on the `RemoteServices.trigger_remote_door_unlock`.
