### PR TITLE
Fix issue 101, add OPEN_TILT to lid states in state.py

### DIFF
--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -93,7 +93,7 @@ class RemoteServices:
 
         A state update is triggered after this, as the lock state of the vehicle changes.
         """
-        _LOGGER.debug('Triggering remote door lock')
+        _LOGGER.debug('Triggering remote door unlock')
         # needs to be called via POST, GET is not working
         self._trigger_remote_service(_Services.REMOTE_DOOR_UNLOCK, post=True)
         result = self._block_until_done(_Services.REMOTE_DOOR_UNLOCK)
@@ -105,7 +105,7 @@ class RemoteServices:
 
         A state update is NOT triggered after this, as the vehicle state is unchanged.
         """
-        _LOGGER.debug('Triggering remote light flash')
+        _LOGGER.debug('Triggering remote horn sound')
         # needs to be called via POST, GET is not working
         self._trigger_remote_service(_Services.REMOTE_HORN, post=True)
         return self._block_until_done(_Services.REMOTE_HORN)

--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -23,6 +23,7 @@ class LidState(Enum):
     OPEN = 'OPEN'
     INTERMEDIATE = 'INTERMEDIATE'
     INVALID = 'INVALID'
+    OPEN_TILT = 'OPEN_TILT'
 
 
 class LockState(Enum):


### PR DESCRIPTION
https://github.com/m1n3rva/bimmer_connected/issues/101#issue-435298664

Fixes #101 

This state is returned by the server when the sunroof lid when it's titled up rather than fully opened. Errors are raised when vehicle state is polled and the sunroof is in this position. This change addresses that problem.