### PR TITLE
add OPEN_TILT to LidState for sunroof.

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -21,6 +21,7 @@ class LidState(Enum):
     """Possible states of the hatch, trunk, doors, windows, sun roof."""
     CLOSED = 'CLOSED'
     OPEN = 'OPEN'
+    OPEN_TILT = 'OPEN_TILT'
     INTERMEDIATE = 'INTERMEDIATE'
     INVALID = 'INVALID'
 


### PR DESCRIPTION
encountered a ValueError when sunroof was tilted up (vs retracted) while parked to provide some cooling. seems like an easy fix.

error:
```python
Update for binary_sensor.bmw_x1_windows fails
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/homeassistant/helpers/entity.py", line 220, in async_update_ha_state
    await self.async_device_update()
  File "/usr/local/lib/python3.6/dist-packages/homeassistant/helpers/entity.py", line 377, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/dist-packages/homeassistant/components/bmw_connected_drive/binary_sensor.py", line 149, in update
    self._state = not vehicle_state.all_windows_closed
  File "/home/hass/.homeassistant/deps/lib/python3.6/site-packages/bimmer_connected/state.py", line 208, in all_windows_closed
    return len(list(self.open_windows)) == 0
  File "/home/hass/.homeassistant/deps/lib/python3.6/site-packages/bimmer_connected/state.py", line 203, in open_windows
    return [lid for lid in self.windows if not lid.is_closed]
  File "/home/hass/.homeassistant/deps/lib/python3.6/site-packages/bimmer_connected/state.py", line 203, in <listcomp>
    return [lid for lid in self.windows if not lid.is_closed]
  File "/home/hass/.homeassistant/deps/lib/python3.6/site-packages/bimmer_connected/state.py", line 348, in is_closed
    return self.state == LidState.CLOSED
  File "/home/hass/.homeassistant/deps/lib/python3.6/site-packages/bimmer_connected/state.py", line 343, in state
    return LidState(getattr(self._vehicle_state, self.name))
  File "/usr/lib/python3.6/enum.py", line 293, in __call__
    return cls.__new__(cls, value)
  File "/usr/lib/python3.6/enum.py", line 535, in __new__
    return cls._missing_(value)
  File "/usr/lib/python3.6/enum.py", line 548, in _missing_
    raise ValueError("%r is not a valid %s" % (value, cls.__name__))
ValueError: 'OPEN_TILT' is not a valid LidState
```