### PR TITLE
Fix fingerprint when bimmer_connected is installed via pip

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -10,8 +10,8 @@ This library is not affiliated with or endorsed by BMW Group.
 
 import datetime
 import logging
+import pathlib
 import urllib
-import os
 import json
 from threading import Lock
 from typing import Callable, List
@@ -38,7 +38,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, username: str, password: str, region: Regions, log_responses: str = None) -> None:
+    def __init__(self, username: str, password: str, region: Regions, log_responses: pathlib.Path = None) -> None:
         self._region = region
         self._server_url = None
         self._username = username
@@ -147,8 +147,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
         output_path = None
         count = 0
 
-        while output_path is None or os.path.exists(output_path):
-            output_path = os.path.join(self._log_responses, '{}_{}.txt'.format(logfilename, count))
+        while output_path is None or output_path.exists():
+            output_path = self._log_responses / '{}_{}.txt'.format(logfilename, count)
             count += 1
 
         with open(output_path, 'w') as logfile:

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -4,14 +4,11 @@
 import argparse
 import logging
 import json
-import os
 import time
+from pathlib import Path
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name, valid_regions
 from bimmer_connected.vehicle import VehicleViewDirection
-
-FINGERPRINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'vehicle_fingerprint')
 
 
 def main() -> None:
@@ -68,9 +65,8 @@ def get_status(args) -> None:
 
 def fingerprint(args) -> None:
     """Save the vehicle fingerprint."""
-    time_str = time.strftime("%Y-%m-%d_%H-%M-%S")
-    time_dir = os.path.join(FINGERPRINT_DIR, time_str)
-    os.makedirs(time_dir)
+    time_dir = Path.cwd() / 'vehicle_fingerprint' / time.strftime("%Y-%m-%d_%H-%M-%S")
+    time_dir.mkdir(parents=True)
 
     account = ConnectedDriveAccount(args.username, args.password, get_region_from_name(args.region),
                                     log_responses=time_dir)


### PR DESCRIPTION
I noticed that fingerprint doesn't work because it attempts to write the data next to where the account.py implementation is (`/usr/local/...`)

I've modified the code to use the current working directory.