### PR TITLE
Add ability to retry comms on HTTP 500 error

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -142,7 +142,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
 
             if response.status_code != expected_response:
                 if response.status_code == 500:
-                    _LOGGER.debug("Error 500 on attempt %d, waiting %d seconds before retry", i+1, self._retry_delay_on_500_error)
+                    _LOGGER.debug("Error 500 on attempt %d, waiting %d seconds before retry", i+1,
+                                  self._retry_delay_on_500_error)
                     if self._retry_delay_on_500_error > 0:
                         sleep(self._retry_delay_on_500_error)
                     continue

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -136,8 +136,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             if response.status_code != expected_response:
                 if response.status_code == 500:
                     _LOGGER.debug("Error 500 on attempt %d", i+1)
-                    continue;
-                
+                    continue
+
                 error_description = ERROR_CODE_MAPPING.get(response.status_code, "UNKNOWN_ERROR")
                 msg = ("The BMW Connected Drive portal returned an error: {} (received status code {} and expected {})."
                        .format(error_description, response.status_code, expected_response))
@@ -146,7 +146,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 raise IOError(msg)
             else:
                 break
-        
+
         self._log_response_to_file(response, logfilename)
         return response
 

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -42,7 +42,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, username: str, password: str, region: Regions, log_responses: str = None, retries_on_500_error: int = 0) -> None:
+    def __init__(self, username: str, password: str, region: Regions, log_responses: str = None,
+                 retries_on_500_error: int = 0) -> None:
         self._region = region
         self._server_url = None
         self._username = username
@@ -129,9 +130,11 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
 
         for i in range(self._retries_on_500_error + 1):
             if post:
-                response = requests.post(url, headers=headers, data=data, allow_redirects=allow_redirects, params=params)
+                response = requests.post(url, headers=headers, data=data, allow_redirects=allow_redirects,
+                                         params=params)
             else:
-                response = requests.get(url, headers=headers, data=data, allow_redirects=allow_redirects, params=params)
+                response = requests.get(url, headers=headers, data=data, allow_redirects=allow_redirects,
+                                        params=params)
 
             if response.status_code != expected_response:
                 if response.status_code == 500:
@@ -144,8 +147,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 _LOGGER.debug(msg)
                 _LOGGER.debug(response.text)
                 raise IOError(msg)
-            else:
-                break
+            break
 
         self._log_response_to_file(response, logfilename)
         return response


### PR DESCRIPTION
I find that (at least in my region), the Connected Drive servers can be pretty flaky sometimes and return a 500 error which will work with a retry 99% of the time.

This pull request adds the ability to configure this library to automatically retry HTTP 500 errors for the specified number of retries - although defaults to not doing this to preserve existing behavior.

Originally I'd done this in my code, but it's more reliable to do it in your library (if you're willing to accept this PR), as you have access to the HTTP response code. Otherwise I have to parse your error message and hope it stays the same or similar!