### PR TITLE
WIP: Use new Connected Drive url

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -13,13 +13,13 @@ import logging
 import urllib
 import os
 import json
-from threading import Lock
+from threading import RLock
 from typing import Callable, List
 import requests
 
-from bimmer_connected.country_selector import Regions, get_server_url
+from bimmer_connected.country_selector import Regions, get_gcdm_oauth_endpoint
 from bimmer_connected.vehicle import ConnectedDriveVehicle
-from bimmer_connected.const import AUTH_URL, VEHICLES_URL, ERROR_CODE_MAPPING
+from bimmer_connected.const import AUTH_URL, PROFILE_URL, VEHICLES_URL, ERROR_CODE_MAPPING
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,29 +55,83 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
         self._retries_on_500_error = retries_on_500_error
         #: list of vehicles associated with this account.
         self._vehicles = []
-        self._lock = Lock()
+        self._lock = RLock()
         self._update_listeners = []
 
         self._get_vehicles()
 
     def _get_oauth_token(self) -> None:
-        """Get a new auth token from the server."""
+        """Get a new auth token from the server, based on user GCDM tokens"""
         with self._lock:
             if self._token_expiration is not None and datetime.datetime.now() < self._token_expiration:
                 _LOGGER.debug('Old token is still valid. Not getting a new one.')
                 return
 
             _LOGGER.debug('getting new oauth token')
+
+            # Get GCDM tokens with username/password
+            gcdm_tokens = self._get_gcdm_token()
+
+            # We need a session for cross-request cookies
+            oauth_session = requests.Session()
+
+            # Generate a state_token for OAuth (but don't sign in yet)
+            oauth_headers = {"ocp-apim-subscription-key": "01756ba1-e792-413b-81bd-91c4bd7807f5"}
+            oauth_state_request = oauth_session.get(
+                url=PROFILE_URL + "/api/Account/ExternalLogin",
+                headers=oauth_headers,
+                params={
+                    "provider": "GCDM",
+                    "response_type": "token",
+                    "redirect_uri": PROFILE_URL + "/",
+                    "client_id": "self",
+                },
+            )
+            state_token = urllib.parse.parse_qs(oauth_state_request.url).get("state")[0]
+
+            # With state_token, GCDM access_token and GCDM refresh_token, retrieve a authenticated session cookie
+            oauth_session.get(
+                url=PROFILE_URL + "/oauth_callback.html",
+                headers=oauth_headers,
+                params={
+                    "scope": "authenticate_user",
+                    "refresh": gcdm_tokens["refresh_token"],
+                    "state": state_token,
+                    "token": gcdm_tokens["access_token"],
+                },
+                allow_redirects=False,
+            )
+
+            # With the session cookie, call External Login again to get OAuth access_token, refresh_token and expiry
+            oauth_token_request = oauth_session.get(
+                url=PROFILE_URL + "/api/Account/ExternalLogin",
+                headers=oauth_headers,
+                params={
+                    "provider": "GCDM",
+                    "response_type": "token",
+                    "redirect_uri": PROFILE_URL + "/",
+                    "client_id": "self",
+                },
+            )
+            oauth_tokens = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(oauth_token_request.url).fragment))
+
+            self._oauth_token = oauth_tokens['access_token']
+            # not sure how to use the refresh_token, but might be useful in the future...
+            self._refresh_token = oauth_tokens['refresh_token']
+            expiration_time = int(oauth_tokens['expires_in'])
+            self._token_expiration = datetime.datetime.now() + datetime.timedelta(seconds=expiration_time)
+            _LOGGER.debug('got new token %s with expiration date %s', self._oauth_token, self._token_expiration)
+
+    def _get_gcdm_token(self) -> dict:
+        """Get a new GCDM (Global Customer Data Management) token from the server."""
+        with self._lock:
+
+            _LOGGER.debug('getting new GCDM token')
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Content-Length": "124",
-                "Connection": "Keep-Alive",
-                "Host": self.server_url,
-                "Accept-Encoding": "gzip",
                 "Authorization": "Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGNEanli"
                                  "TEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==",
                 "Credentials": "nQv6CqtxJuXWP74xf3CJwUEP:1zDHx6un4cDjybLENN3kyfumX2kEYigWPcQpdvDRpIBk7rOJ",
-                "User-Agent": "okhttp/2.60",
             }
 
             # we really need all of these parameters
@@ -89,7 +143,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             }
 
             data = urllib.parse.urlencode(values)
-            url = AUTH_URL.format(server=self.server_url)
+            url = AUTH_URL.format(gcdm_oauth_endpoint=get_gcdm_oauth_endpoint(self._region))
             try:
                 response = self.send_request(url, data=data, headers=headers, allow_redirects=False,
                                              expected_response=200, post=True)
@@ -99,13 +153,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 _LOGGER.exception(exception)
                 raise OSError(msg) from exception
 
-            response_json = response.json()
-            self._oauth_token = response_json['access_token']
-            # not sure how to use the refresh_token, but might be useful in the future...
-            self._refresh_token = response_json['refresh_token']
-            expiration_time = response_json['expires_in']
-            self._token_expiration = datetime.datetime.now() + datetime.timedelta(seconds=expiration_time)
-            _LOGGER.debug('got new token %s with expiration date %s', self._oauth_token, self._token_expiration)
+            return response.json()
 
     @property
     def request_header(self):
@@ -192,18 +240,11 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
 
         return json_data
 
-    @property
-    def server_url(self) -> str:
-        """Get the url of the server for this country."""
-        if self._server_url is None:
-            self._server_url = get_server_url(self._region)
-        return self._server_url
-
     def _get_vehicles(self):
         """Retrieve list of vehicle for the account."""
         _LOGGER.debug('Getting vehicle list')
         self._get_oauth_token()
-        response = self.send_request(VEHICLES_URL.format(server=self.server_url), headers=self.request_header,
+        response = self.send_request(VEHICLES_URL, headers=self.request_header,
                                      logfilename='vehicles')
 
         for vehicle_dict in response.json()['vehicles']:

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -1,7 +1,8 @@
 """URLs for different services and error code mapping."""
 
-AUTH_URL = 'https://{server}/gcdm/oauth/token'
-BASE_URL = 'https://{server}/webapi/v1'
+AUTH_URL = 'https://customer.bmwgroup.com/{gcdm_oauth_endpoint}/token'
+PROFILE_URL = 'https://myc-profile.bmwgroup.com'
+BASE_URL = PROFILE_URL + '/api/gateway/brs/webapi/v1'
 
 VEHICLES_URL = BASE_URL + '/user/vehicles'
 VEHICLE_VIN_URL = VEHICLES_URL + '/{vin}'

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -14,10 +14,10 @@ class Regions(Enum):
 
 
 #: Mapping from regions to servers
-_SERVER_URLS = {
-    Regions.NORTH_AMERICA: 'b2vapi.bmwgroup.us',
-    Regions.REST_OF_WORLD: 'b2vapi.bmwgroup.com',
-    Regions.CHINA: 'b2vapi.bmwgroup.cn:8592'
+_GCDM_OAUTH_ENDPOINTS = {
+    Regions.NORTH_AMERICA: 'gcdm/usa/oauth',
+    Regions.REST_OF_WORLD: 'gcdm/oauth',
+    Regions.CHINA: 'gcdm/china/oauth'
 }
 
 
@@ -39,6 +39,6 @@ def get_region_from_name(name: str) -> Regions:
         ','.join(valid_regions())))
 
 
-def get_server_url(region: Regions) -> str:
+def get_gcdm_oauth_endpoint(region: Regions) -> str:
     """Get the url of the server for the region."""
-    return _SERVER_URLS[region]
+    return _GCDM_OAUTH_ENDPOINTS[region]

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 _POLLING_CYCLE = 1
 
 #: maximum number of seconds to wait for the server to return a positive answer
-_POLLING_TIMEOUT = 60
+_POLLING_TIMEOUT = 180
 
 #: time in seconds to wait before updating the vehicle state from the server
 _UPDATE_AFTER_REMOTE_SERVICE_DELAY = 10
@@ -128,7 +128,7 @@ class RemoteServices:
         You can choose if you want a POST or a GET operation.
         """
         data = {'serviceType': service_id.value}
-        url = REMOTE_SERVICE_URL.format(vin=self._vehicle.vin, server=self._account.server_url)
+        url = REMOTE_SERVICE_URL.format(vin=self._vehicle.vin)
 
         return self._account.send_request(url, post=post, data=data)
 
@@ -156,7 +156,6 @@ class RemoteServices:
         """
         _LOGGER.debug('getting remote service status')
         url = REMOTE_SERVICE_STATUS_URL.format(
-            server=self._account.server_url,
             vin=self._vehicle.vin,
             service_type=service.value)
         response = self._account.send_request(url)

--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -126,7 +126,7 @@ class VehicleState:  # pylint: disable=too-many-public-methods
             'dlon': self._vehicle.observer_longitude,
         }
         response = self._account.send_request(
-            VEHICLE_STATUS_URL.format(server=self._account.server_url, vin=self._vehicle.vin), logfilename='status',
+            VEHICLE_STATUS_URL.format(vin=self._vehicle.vin), logfilename='status',
             params=params)
         attributes = response.json()['vehicleStatus']
         self._attributes = attributes

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -197,7 +197,6 @@ class ConnectedDriveVehicle:
         """
         url = VEHICLE_IMAGE_URL.format(
             vin=self.vin,
-            server=self._account.server_url,
             width=width,
             height=height,
             view=direction.value,
@@ -235,7 +234,6 @@ class ConnectedDriveVehicle:
         """Send a point of interest to the vehicle."""
         url = VEHICLE_POI_URL.format(
             vin=self.vin,
-            server=self._account.server_url
         )
         header = self._account.request_header
         # the accept field of the header needs to be updated as we want a png not the usual JSON


### PR DESCRIPTION
Fixes #130 and updates all requests to the Connected Drive API to the one currently in use by the [BMW Connected Android App](https://play.google.com/store/apps/details?id=de.bmw.connected). This should make it possible to implement Remote 3D view (#99).
While the code for logging in is more complex, apparently all following API calls can be done to one load-balanced URL. 

This PR is still work-in-progress with the following open points:

- [ ] Test thoroughly with a `rest_of_world` electronic/newer vehicle (my car is too old for more than basic status & sendpoi)
- [ ] Test thoroughly with a `usa` vehicle. Login has been tested and should work.
- [ ] Test thoroughly with a `china` vehicle. No test done at all.
- [ ] Fix `pytest`. Haven't looked into it, but probably we need to adjust/enhance the MockupBackend for the new OAuth flow.

Except for some URL changes, the main differences are in `account.py`: 
- We can re-use most of the original `_get_oauth_token` code as `_get_gcdm_token`, just need a new endpoint. This method still does the inital login and handles the user credentials. The result are now returned as `dict`.
- The new `_get_oauth_token` uses the GCDM tokens (apparently for *Global Customer Data Managment*) and aquires OAuth API tokens by:
  1. Obtaining a `state` token
  2. Using the `state`, the GCDM `access` and the GCDM `refresh` token to get a authenticated `session cookie`
  3. With the `session cookie` we can extract the API `access` tokens etc. from the `return url`. 

Many thanks to @ronmichael for extracting the login workflow from the Android app! 
@robthebold, @gerard33, @timmccor can you please check as much as possible? While in theory everything should continue working, this could very well break everything 💣 

Looking forward to get some feedback :)