### PR TITLE
Update tox python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ install: pip install -U tox coveralls
 matrix:
   fast_finish: true
   include:
-  - python: '3.4'
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.6'
     env: TOXENV=py36
+  - python: '3.7'
+    env: TOXENV=py37
+  - python: '3.8'
+    env: TOXENV=py38
   - python: '3.6'
     env: TOXENV=flake8
   - python: '3.6'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, pylint, flake8, docs
+envlist = py35, py36, py37, py38, pylint, flake8, docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
In accordance with [Status of Python Branches](https://devguide.python.org/#status-of-python-branches) I've updated tox and travis to include/exclude python versions for our test cases:

- Removed Python 3.4
- Added Python 3.7
- Added Python 3.8

Pylint, flake8 and docs are still on Python 3.6 but could of course be updated as well.