### PR TITLE
Fix __getattr__ KeyError

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -113,7 +113,7 @@ class VehicleState:  # pylint: disable=too-many-public-methods
         """Constructor."""
         self._account = account
         self._vehicle = vehicle
-        self._attributes = None
+        self._attributes = {}
 
     def update_data(self) -> None:
         """Read new status data from the server."""
@@ -304,7 +304,7 @@ class VehicleState:  # pylint: disable=too-many-public-methods
 
     def __getattr__(self, item):
         """Generic get function for all backend attributes."""
-        return self._attributes[item]
+        return self._attributes.get(item)
 
     @property
     @backend_parameter


### PR DESCRIPTION
Fixes #142 
Fixes #141 
Fixes #129 

Fix this log :
```shell
  File "/usr/local/lib/python3.7/site-packages/bimmer_connected/state.py", line 307, in __getattr__
    return self._attributes[item]
KeyError: '[the_key]'
```

Will need a release to f!x home-assistant/home-assistant#31704.

But first need a CI fix : `rrequirements.txt` not found ...