### PR TITLE
Use customer.bmwgroup.com to get token

### DIFF
--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -1,6 +1,6 @@
 """URLs for different services and error code mapping."""
 
-AUTH_URL = 'https://{server}/gcdm/oauth/token'
+AUTH_URL = 'https://customer.bmwgroup.com/{gcdm_oauth_endpoint}/authenticate'
 BASE_URL = 'https://{server}/webapi/v1'
 
 VEHICLES_URL = BASE_URL + '/user/vehicles'

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -20,6 +20,13 @@ _SERVER_URLS = {
     Regions.CHINA: 'b2vapi.bmwgroup.cn:8592'
 }
 
+#: Mapping from regions to servers
+_GCDM_OAUTH_ENDPOINTS = {
+    Regions.NORTH_AMERICA: 'gcdm/usa/oauth',
+    Regions.REST_OF_WORLD: 'gcdm/oauth',
+    Regions.CHINA: 'gcdm/oauth'
+}
+
 
 def valid_regions() -> List[str]:
     """Get list of valid regions as strings."""
@@ -42,3 +49,7 @@ def get_region_from_name(name: str) -> Regions:
 def get_server_url(region: Regions) -> str:
     """Get the url of the server for the region."""
     return _SERVER_URLS[region]
+
+def get_gcdm_oauth_endpoint(region: Regions) -> str:
+    """Get the url of the server for the region."""
+    return _GCDM_OAUTH_ENDPOINTS[region]


### PR DESCRIPTION
Fixes #150. 

Uses `customer.bmwgroup.com` for authentication. This should work for `rest_of_world` and `us`, as those URLs are defined in [https://customer.bmwgroup.com/one/app/oauth.js](https://customer.bmwgroup.com/one/app/oauth.js). 

For `china`, this needs to be tested by someone with a `china` vehicle. Workaround would be an additional condition to use the old authentication scheme (not implemented yet).

Many thanks @janhaa and @Timo47v for pointing this out!

@gerard33 could you please merge this (and then update the HA component as well)?