### PR TITLE
Fix all the tests (except py35)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ install: pip install -U tox coveralls
 matrix:
   fast_finish: true
   include:
-  - python: '3.4'
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.6'
     env: TOXENV=py36
+  - python: '3.7'
+    env: TOXENV=py37
+  - python: '3.8'
+    env: TOXENV=py38
   - python: '3.6'
     env: TOXENV=flake8
   - python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ install: pip install -U tox coveralls
 matrix:
   fast_finish: true
   include:
-  - python: '3.5'
-    env: TOXENV=py35
   - python: '3.6'
     env: TOXENV=py36
   - python: '3.7'

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -50,6 +50,7 @@ def get_server_url(region: Regions) -> str:
     """Get the url of the server for the region."""
     return _SERVER_URLS[region]
 
+
 def get_gcdm_oauth_endpoint(region: Regions) -> str:
     """Get the url of the server for the region."""
     return _GCDM_OAUTH_ENDPOINTS[region]

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -185,9 +185,9 @@ class ConnectedDriveVehicle:
             result += LIDS
             result += WINDOWS
             result += self.drive_train_attributes
-            result += ['DCS_CCH_Activation', 'DCS_CCH_Ongoing', 'condition_based_services', 'check_control_messages',
-                       'door_lock_state', 'internalDataTimeUTC', 'lights_parking', 'lids', 'windows',
-                       'positionLight', 'last_update_reason', 'singleImmediateCharging']
+            result += ['DCS_CCH_Activation', 'DCS_CCH_Ongoing', 'condition_based_services',
+                       'check_control_messages', 'door_lock_state', 'internalDataTimeUTC',
+                       'parking_lights', 'positionLight', 'last_update_reason', 'singleImmediateCharging']
         return result
 
     def get_vehicle_image(self, width: int, height: int, direction: VehicleViewDirection) -> bytes:

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -188,6 +188,8 @@ class ConnectedDriveVehicle:
             result += ['DCS_CCH_Activation', 'DCS_CCH_Ongoing', 'condition_based_services',
                        'check_control_messages', 'door_lock_state', 'internalDataTimeUTC',
                        'parking_lights', 'positionLight', 'last_update_reason', 'singleImmediateCharging']
+            # required for existing Home Assistant binary sensors
+            result += ['lights_parking', 'lids', 'windows']
         return result
 
     def get_vehicle_image(self, width: int, height: int, direction: VehicleViewDirection) -> bytes:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -119,6 +119,10 @@ class BackendMock:
         """Constructor."""
         self.last_request = []
         self.responses = [
+            MockResponse('https://.+/gcdm/oauth/token',
+                         headers=_AUTH_RESPONSE_HEADERS,
+                         data_files=['G31_NBTevo/auth_response.json'],
+                         status_code=200),
             MockResponse('https://.+/gcdm/(.+/)?oauth/authenticate',
                          headers=_AUTH_RESPONSE_HEADERS,
                          data_files=['G31_NBTevo/auth_response.json'],

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -68,6 +68,9 @@ ADDITIONAL_ATTRIBUTES = [
     'remaining_range_total',    # added by bimmer_connected
     'charging_time_remaining',  # only present while charging
     'sunroof',                  # not available in all vehicles
+    'lids',                     # required for existing Home Assistant binary sensors
+    'windows',                  # required for existing Home Assistant binary sensors
+    'lights_parking',           # required for existing Home Assistant binary sensors
 ]
 
 # there attributes are not (yet) implemented
@@ -77,6 +80,8 @@ MISSING_ATTRIBUTES = [
     'maxRangeElectricMls',        # we're not using miles
     'chargingTimeRemaining',      # only present while charging
     'sunroof',                    # not available in all vehicles
+    'lights_parking',             # required for existing Home Assistant binary sensors
+
 ]
 
 POI_DATA = {

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,6 +17,7 @@ I01_VIN = 'I01_VIN'
 F15_VIN = 'F15_VIN'
 I01_NOREX_VIN = 'I01_NOREX_VIN'
 F45_VIN = 'F45_VIN'
+F31_VIN = 'F31_VIN'
 
 #: Mapping of VINs to test data directories
 TEST_VEHICLE_DATA = {
@@ -26,6 +27,7 @@ TEST_VEHICLE_DATA = {
     I01_NOREX_VIN: 'I01_NOREX',
     F15_VIN: 'F15',
     F45_VIN: 'F45',
+    F31_VIN: 'F31',
 }
 
 _AUTH_RESPONSE_HEADERS = {
@@ -37,7 +39,10 @@ _AUTH_RESPONSE_HEADERS = {
     'X-NodeID': '02',
     'Max-Forwards': '20',
     'Date': 'Sun, 11 Mar 2018 08:16:13 GMT',
-    'Content-Encoding': 'gzip'}
+    'Content-Encoding': 'gzip',
+    'Location': ('https://www.bmw-connecteddrive.com/app/static/external-dispatch.html'
+                 '#access_token=TOKEN&token_type=Bearer&expires_in=7199')
+}
 
 # VehicleState has different names than the json file. So we need to map some of the
 # parameters.
@@ -114,10 +119,10 @@ class BackendMock:
         """Constructor."""
         self.last_request = []
         self.responses = [
-            MockResponse('https://.+/gcdm/oauth/token',
+            MockResponse('https://.+/gcdm/(.+/)?oauth/authenticate',
                          headers=_AUTH_RESPONSE_HEADERS,
                          data_files=['G31_NBTevo/auth_response.json'],
-                         status_code=200),
+                         status_code=302),
             MockResponse('https://.+/webapi/v1/user/vehicles$',
                          data_files=['vehicles.json']),
         ]

--- a/test/responses/F31/status.json
+++ b/test/responses/F31/status.json
@@ -1,4 +1,6 @@
 {
+  "DCS_CCH_Activation": "NA",	
+  "DCS_CCH_Ongoing": false,
   "vehicleStatus": {
       "position": {
           "lat": 12.3456,

--- a/test/responses/F31/status.json
+++ b/test/responses/F31/status.json
@@ -1,7 +1,5 @@
 {
   "vehicleStatus": {
-      "DCS_CCH_Activation": "NA",
-      "DCS_CCH_Ongoing": false,
       "position": {
           "lat": 12.3456,
           "lon": 34.5678,
@@ -9,7 +7,6 @@
       },
       "steering": "RH",
       "updateTime": "2018-07-25T16:02:04+0200",
-      "vehicleCountry": "GB",
-      "vin": "some_vin"
+      "vin": "F31_VIN"
   }
 }

--- a/test/responses/vehicles.json
+++ b/test/responses/vehicles.json
@@ -348,7 +348,7 @@
     "steering": "RH",
     "vehicleFinder": "ACTIVATED",
     "vehicleFinderRestriction": "NONE",
-    "vin": "some_vin",
+    "vin": "F31_VIN",
     "yearOfConstruction": 2015
   },
   {
@@ -400,7 +400,7 @@
     "statisticsCommunityEnabled": false,
     "steering": "LH",
     "vehicleFinder": "NOT_SUPPORTED",
-    "vin": "some_vin",
+    "vin": "F31_VIN",
     "yearOfConstruction": 2015
   }
   ]

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -18,7 +18,7 @@ class TestAccount(unittest.TestCase):
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.REST_OF_WORLD)
             self.assertIsNotNone(account._oauth_token)
-            self.assertEqual(6, len(account.vehicles))
+            self.assertEqual(8, len(account.vehicles))
             vehicle = account.get_vehicle(G31_VIN)
             self.assertEqual(G31_VIN, vehicle.vin)
 

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -62,12 +62,19 @@ class TestRemoteServices(unittest.TestCase):
             backend_mock.add_response(
                 r'https://.+/webapi/v1/user/vehicles/{vin}/serviceExecutionStatus\?serviceType={service_type}'.format(
                     vin=G31_VIN, service_type=service),
+                r'https://.+/webapi/v1/user/vehicles/{vin}/status'.format(
+                    vin=G31_VIN),
                 data_files=[
                     _RESPONSE_PENDING,
                     _RESPONSE_PENDING,
                     _RESPONSE_DELIVERED,
                     _RESPONSE_DELIVERED,
                     _RESPONSE_EXECUTED])
+
+            backend_mock.add_response(
+                r'https://.+/webapi/v1/user/vehicles/{vin}/status'.format(
+                    vin=G31_VIN),
+                data_files=[_RESPONSE_EXECUTED])
 
             with mock.patch('bimmer_connected.account.requests', new=backend_mock):
                 account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -136,7 +136,7 @@ class TestState(unittest.TestCase):
         """Test if error handling is working correctly."""
         account = unittest.mock.MagicMock(ConnectedDriveAccount)
         state = VehicleState(account, None)
-        self.assertIsNone(state.mileage)  # pylint: disable = pointless-statement
+        self.assertIsNone(state.mileage)
 
     def test_update_data(self):
         """Test update_data method."""
@@ -248,7 +248,6 @@ class TestState(unittest.TestCase):
         ccms = state.check_control_messages
         self.assertEqual(1, len(ccms))
         ccm = ccms[0]
-
         self.assertEqual(955, ccm["ccmId"])
         self.assertEqual(41544, ccm["ccmMileage"])
         self.assertIn("Tyre pressure", ccm["ccmDescriptionShort"])

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -136,8 +136,7 @@ class TestState(unittest.TestCase):
         """Test if error handling is working correctly."""
         account = unittest.mock.MagicMock(ConnectedDriveAccount)
         state = VehicleState(account, None)
-        with self.assertRaises(ValueError):
-            state.mileage  # pylint: disable = pointless-statement
+        self.assertIsNone(state.mileage)  # pylint: disable = pointless-statement
 
     def test_update_data(self):
         """Test update_data method."""
@@ -248,9 +247,9 @@ class TestState(unittest.TestCase):
 
         ccms = state.check_control_messages
         self.assertEqual(1, len(ccms))
-
         ccm = ccms[0]
-        self.assertEqual(955, ccm.ccm_id)
-        self.assertEqual(41544, ccm.mileage)
-        self.assertIn("Tyre pressure", ccm.description_short)
-        self.assertIn("continue driving", ccm.description_long)
+
+        self.assertEqual(955, ccm["ccmId"])
+        self.assertEqual(41544, ccm["ccmMileage"])
+        self.assertIn("Tyre pressure", ccm["ccmDescriptionShort"])
+        self.assertIn("continue driving", ccm["ccmDescriptionLong"])

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest import mock
 from test import load_response_json, BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_REGION, \
-    G31_VIN, F48_VIN, I01_VIN, I01_NOREX_VIN, F15_VIN, F45_VIN, TEST_VEHICLE_DATA, \
+    G31_VIN, F48_VIN, I01_VIN, I01_NOREX_VIN, F15_VIN, F45_VIN, F31_VIN, TEST_VEHICLE_DATA, \
     ATTRIBUTE_MAPPING, MISSING_ATTRIBUTES, ADDITIONAL_ATTRIBUTES, POI_DATA, POI_REQUEST
 
 from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType, PointOfInterest
@@ -42,8 +42,8 @@ class TestVehicle(unittest.TestCase):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
 
         for vehicle in account.vehicles:
-            print(vehicle.name)
-            self.assertEqual(vehicle.vin in [G31_VIN, F48_VIN, F15_VIN, I01_VIN, F45_VIN],
+            print(vehicle.vin, vehicle.name, vehicle.has_internal_combustion_engine, vehicle.has_hv_battery)
+            self.assertEqual(vehicle.vin in [G31_VIN, F48_VIN, F15_VIN, I01_VIN, F45_VIN, F31_VIN],
                              vehicle.has_internal_combustion_engine)
             self.assertEqual(vehicle.vin in [I01_VIN, I01_NOREX_VIN],
                              vehicle.has_hv_battery)
@@ -71,6 +71,8 @@ class TestVehicle(unittest.TestCase):
             existing_attributes = sorted([ATTRIBUTE_MAPPING.get(a, a) for a in existing_attributes
                                           if a not in MISSING_ATTRIBUTES])
             expected_attributes = sorted([a for a in vehicle.available_attributes if a not in ADDITIONAL_ATTRIBUTES])
+            print(existing_attributes)
+            print(expected_attributes)
             self.assertListEqual(existing_attributes, expected_attributes)
 
     def test_parsing_of_poi_min_attributes(self):

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -42,7 +42,6 @@ class TestVehicle(unittest.TestCase):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
 
         for vehicle in account.vehicles:
-            print(vehicle.vin, vehicle.name, vehicle.has_internal_combustion_engine, vehicle.has_hv_battery)
             self.assertEqual(vehicle.vin in [G31_VIN, F48_VIN, F15_VIN, I01_VIN, F45_VIN, F31_VIN],
                              vehicle.has_internal_combustion_engine)
             self.assertEqual(vehicle.vin in [I01_VIN, I01_NOREX_VIN],
@@ -71,8 +70,6 @@ class TestVehicle(unittest.TestCase):
             existing_attributes = sorted([ATTRIBUTE_MAPPING.get(a, a) for a in existing_attributes
                                           if a not in MISSING_ATTRIBUTES])
             expected_attributes = sorted([a for a in vehicle.available_attributes if a not in ADDITIONAL_ATTRIBUTES])
-            print(existing_attributes)
-            print(expected_attributes)
             self.assertListEqual(existing_attributes, expected_attributes)
 
     def test_parsing_of_poi_min_attributes(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pylint, flake8, docs
+envlist = py36, py37, py38, pylint, flake8, docs
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, pylint, flake8, docs
+envlist = py35, py36, py37, py38, pylint, flake8, docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Due to the new authorization endpoint, even more tests were failing. When trying to correct them, I fixed all.
Fixes #134. Many thanks to @timmccor for #136.

Only test for Python 3.5 still fails due to dictionaries not preserving order. But before using an OrderedDict, I'd rather remove support for Python 3.5.