### PR TITLE
Send message to car & send POI from OSM

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -6,6 +6,10 @@ import logging
 import json
 import os
 import time
+import sys
+
+import requests
+
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name, valid_regions
 from bimmer_connected.vehicle import VehicleViewDirection, PointOfInterest, Message
@@ -55,6 +59,17 @@ def main() -> None:
     sendpoi_parser.add_argument('--country', help='(optional, display only) Country of the POI',
                                 nargs='?', default=None)
     sendpoi_parser.set_defaults(func=send_poi)
+
+    sendpoi_from_address_parser = subparsers.add_parser('sendpoi_from_address',
+                                                        description=('send a point of interest from a street address'
+                                                                     ' to the vehicle'))
+    _add_default_arguments(sendpoi_from_address_parser)
+    sendpoi_from_address_parser.add_argument('vin', help='vehicle identification number')
+    sendpoi_from_address_parser.add_argument('-n', '--name', help='(optional, display only) Name of the POI',
+                                             nargs='?', default=None)
+    sendpoi_from_address_parser.add_argument('-a', '--address', nargs='+',
+                                             help="address ('street, city, zip, country' etc)")
+    sendpoi_from_address_parser.set_defaults(func=send_poi_from_address)
 
     message_parser = subparsers.add_parser('sendmessage', description='send a text message to the vehicle')
     _add_default_arguments(message_parser)
@@ -134,6 +149,39 @@ def send_poi(args) -> None:
     vehicle = account.get_vehicle(args.vin)
     poi = PointOfInterest(args.latitude, args.longitude, name=args.name,
                           street=args.street, city=args.city, postalCode=args.postalcode, country=args.country)
+    msg = Message.from_poi(poi)
+    vehicle.send_message(msg)
+
+
+def send_poi_from_address(args) -> None:
+    """Create Point of Interest from OSM Nominatim and send to car."""
+    account = ConnectedDriveAccount(args.username, args.password, get_region_from_name(args.region))
+    vehicle = account.get_vehicle(args.vin)
+    address = [(str(' '.join(args.address)))]
+    try:
+        response = requests.get("https://nominatim.openstreetmap.org",
+                                params={
+                                    "q": address,
+                                    "format": "json",
+                                    "addressdetails": 1,
+                                    "limit": 1
+                                }).json()[0]
+    except IndexError:
+        print('\nAddress not found')
+        sys.exit(1)
+    lat = response["lat"]
+    long = response["lon"]
+    name = args.name
+    address = response.get("address", {})
+    street = address.get("road")
+    city = address.get("city")
+    town = address.get("town")
+    city = town if city is None and town is not None else None
+    postcode = address.get("postcode")
+    country = address.get("country")
+
+    print("\nSending '" + lat, long, name, street, city, postcode, country + "' to your car\n")
+    poi = PointOfInterest(lat, long, name=args.name, street=street, city=city, postalCode=postcode, country=country)
     msg = Message.from_poi(poi)
     vehicle.send_message(msg)
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -108,6 +108,18 @@ POI_REQUEST = {
             "%2C+%22phoneNumbers%22%3A+%5B%22%2B1+408-562-4949%22%5D%7D%7D")
 }
 
+MESSAGE_DATA = {
+    "min": {"text": "Message without subject!"},
+    "all": {"subject": "This is a subject...", "text": "... with some message!"}
+}
+
+MESSAGE_REQUEST = {
+    "min": ("data=%7B%22poi%22%3A+%7B%22additionalInfo%22%3A+%22Message+without+subject%21%22%7D%7D"),
+    "all": ("data=%7B%22poi%22%3A+%7B%22name%22%3A+%22This+is+a+subject...%22%2C+%22additionalInfo"
+            "%22%3A+%22...+with+some+message%21%22%7D%7D")
+
+}
+
 
 def load_response_json(filename: str) -> dict:
     """load a stored response from a file"""

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -3,9 +3,10 @@ import unittest
 from unittest import mock
 from test import load_response_json, BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_REGION, \
     G31_VIN, F48_VIN, I01_VIN, I01_NOREX_VIN, F15_VIN, F45_VIN, F31_VIN, TEST_VEHICLE_DATA, \
-    ATTRIBUTE_MAPPING, MISSING_ATTRIBUTES, ADDITIONAL_ATTRIBUTES, POI_DATA, POI_REQUEST
+    ATTRIBUTE_MAPPING, MISSING_ATTRIBUTES, ADDITIONAL_ATTRIBUTES, POI_DATA, POI_REQUEST, \
+    MESSAGE_DATA, MESSAGE_REQUEST
 
-from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType, PointOfInterest
+from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType, PointOfInterest, Message
 from bimmer_connected.account import ConnectedDriveAccount
 
 
@@ -75,7 +76,8 @@ class TestVehicle(unittest.TestCase):
     def test_parsing_of_poi_min_attributes(self):
         """Check that a PointOfInterest can be constructed using only latitude & longitude."""
         poi = PointOfInterest(POI_DATA["lat"], POI_DATA["lon"])
-        self.assertEqual(poi.as_server_request, POI_REQUEST["min"])
+        msg = Message.from_poi(poi)
+        self.assertEqual(msg.as_server_request, POI_REQUEST["min"])
 
     def test_parsing_of_poi_all_attributes(self):
         """Check that a PointOfInterest can be constructed using all attributes."""
@@ -84,4 +86,15 @@ class TestVehicle(unittest.TestCase):
                               city=POI_DATA["city"], postalCode=POI_DATA["postalCode"],
                               country=POI_DATA["country"], website=POI_DATA["website"],
                               phoneNumbers=POI_DATA["phoneNumbers"])
-        self.assertEqual(poi.as_server_request, POI_REQUEST["all"])
+        msg = Message.from_poi(poi)
+        self.assertEqual(msg.as_server_request, POI_REQUEST["all"])
+
+    def test_parsing_of_message_min_attributes(self):
+        """Check that a Message can be constructed using text."""
+        msg = Message.from_text(MESSAGE_DATA["min"]["text"])
+        self.assertEqual(msg.as_server_request, MESSAGE_REQUEST["min"])
+
+    def test_parsing_of_message_all_attributes(self):
+        """Check that a Message can be constructed using text."""
+        msg = Message.from_text(MESSAGE_DATA["all"]["text"], MESSAGE_DATA["all"]["subject"])
+        self.assertEqual(msg.as_server_request, MESSAGE_REQUEST["all"])


### PR DESCRIPTION
Fixes #139 and replaces #115.

Due to some merge conflicts I had to refactor @gps1539's SendPOI OSM code and while doing so implemented a abstract `Message` class that can be used for both standard messages (subject, 255-char message) or POIs.