### PR TITLE
Refactor send_message and send_poi for HomeAssistant

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -192,7 +192,7 @@ def send_poi_from_address(args) -> None:
 
 
 def send_message(args) -> None:
-    """Send Point Of Interest to car."""
+    """Send a message to car."""
     account = ConnectedDriveAccount(args.username, args.password, get_region_from_name(args.region))
     vehicle = account.get_vehicle(args.vin)
     msg_data = dict(

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -245,6 +245,7 @@ class RemoteServices:
 
     def trigger_send_message(self, data: dict) -> RemoteServiceStatus:
         """Send a message to the vehicle.
+
         :param data: A dictonary containing a 'text' and an optional 'subject'
         :type data: dict
 
@@ -259,9 +260,10 @@ class RemoteServices:
 
     def trigger_send_poi(self, data: dict) -> RemoteServiceStatus:
         """Send a PointOfInterest to the vehicle.
+
         :param data: A dictonary containing at least 'lat' and 'lon' and optionally
-                     'name', 'additionalInfo', 'street', 'city', 'postalCode', 'country',
-                     'website' or 'phoneNumbers'
+            'name', 'additionalInfo', 'street', 'city', 'postalCode', 'country',
+            'website' or 'phoneNumbers'
         :type data: dict
 
         A state update is NOT triggered after this, as the vehicle state is unchanged.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -108,16 +108,12 @@ POI_REQUEST = {
             "%2C+%22phoneNumbers%22%3A+%5B%22%2B1+408-562-4949%22%5D%7D%7D")
 }
 
-MESSAGE_DATA = {
-    "min": {"text": "Message without subject!"},
-    "all": {"subject": "This is a subject...", "text": "... with some message!"}
-}
+MESSAGE_DATA = {"subject": "This is a subject...", "text": "This is a message!"}
 
 MESSAGE_REQUEST = {
-    "min": ("data=%7B%22poi%22%3A+%7B%22additionalInfo%22%3A+%22Message+without+subject%21%22%7D%7D"),
+    "min": ("data=%7B%22poi%22%3A+%7B%22additionalInfo%22%3A+%22This+is+a+message%21%22%7D%7D"),
     "all": ("data=%7B%22poi%22%3A+%7B%22name%22%3A+%22This+is+a+subject...%22%2C+%22additionalInfo"
-            "%22%3A+%22...+with+some+message%21%22%7D%7D")
-
+            "%22%3A+%22This+is+a+message%21%22%7D%7D")
 }
 
 

--- a/test/responses/G31_NBTevo/msg_executed.json
+++ b/test/responses/G31_NBTevo/msg_executed.json
@@ -1,0 +1,6 @@
+{
+  "executionStatus" : {
+    "eventId" : "-1",
+    "status" : "EXECUTED"
+  }
+}

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -3,10 +3,9 @@ import unittest
 from unittest import mock
 from test import load_response_json, BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_REGION, \
     G31_VIN, F48_VIN, I01_VIN, I01_NOREX_VIN, F15_VIN, F45_VIN, F31_VIN, TEST_VEHICLE_DATA, \
-    ATTRIBUTE_MAPPING, MISSING_ATTRIBUTES, ADDITIONAL_ATTRIBUTES, POI_DATA, POI_REQUEST, \
-    MESSAGE_DATA, MESSAGE_REQUEST
+    ATTRIBUTE_MAPPING, MISSING_ATTRIBUTES, ADDITIONAL_ATTRIBUTES
 
-from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType, PointOfInterest, Message
+from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType
 from bimmer_connected.account import ConnectedDriveAccount
 
 
@@ -72,29 +71,3 @@ class TestVehicle(unittest.TestCase):
                                           if a not in MISSING_ATTRIBUTES])
             expected_attributes = sorted([a for a in vehicle.available_attributes if a not in ADDITIONAL_ATTRIBUTES])
             self.assertListEqual(existing_attributes, expected_attributes)
-
-    def test_parsing_of_poi_min_attributes(self):
-        """Check that a PointOfInterest can be constructed using only latitude & longitude."""
-        poi = PointOfInterest(POI_DATA["lat"], POI_DATA["lon"])
-        msg = Message.from_poi(poi)
-        self.assertEqual(msg.as_server_request, POI_REQUEST["min"])
-
-    def test_parsing_of_poi_all_attributes(self):
-        """Check that a PointOfInterest can be constructed using all attributes."""
-        poi = PointOfInterest(POI_DATA["lat"], POI_DATA["lon"], name=POI_DATA["name"],
-                              additionalInfo=POI_DATA["additionalInfo"], street=POI_DATA["street"],
-                              city=POI_DATA["city"], postalCode=POI_DATA["postalCode"],
-                              country=POI_DATA["country"], website=POI_DATA["website"],
-                              phoneNumbers=POI_DATA["phoneNumbers"])
-        msg = Message.from_poi(poi)
-        self.assertEqual(msg.as_server_request, POI_REQUEST["all"])
-
-    def test_parsing_of_message_min_attributes(self):
-        """Check that a Message can be constructed using text."""
-        msg = Message.from_text(MESSAGE_DATA["min"]["text"])
-        self.assertEqual(msg.as_server_request, MESSAGE_REQUEST["min"])
-
-    def test_parsing_of_message_all_attributes(self):
-        """Check that a Message can be constructed using text."""
-        msg = Message.from_text(MESSAGE_DATA["all"]["text"], MESSAGE_DATA["all"]["subject"])
-        self.assertEqual(msg.as_server_request, MESSAGE_REQUEST["all"])


### PR DESCRIPTION
This PR provides the necessary refactoring to enable #165 in Home Assistant.

__WARNING!__ This is a breaking change as we're moving the `Message` and `PointOfInterest` classes from `vehicle.py` to `remote_services.py`, where they actually belong. 
The _cli_ is not affected by this change as it has has been adapted already.

See the implementation in `cli.py` on how to call `trigger_send_message` and `trigger_send_poi` correctly. Both require a `dict` as parameter with different keys.