### PR TITLE
PointOfInterest parameters in snake_case

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -153,7 +153,7 @@ def send_poi(args) -> None:
         name=args.name,
         street=args.street,
         city=args.city,
-        postalCode=args.postalcode,
+        postal_code=args.postalcode,
         country=args.country
     )
     vehicle.remote_services.trigger_send_poi(poi_data)
@@ -185,7 +185,7 @@ def send_poi_from_address(args) -> None:
         name=args.name,
         street=address.get("road"),
         city=town if city is None and town is not None else None,
-        postalCode=address.get("postcode"),
+        postal_code=address.get("postcode"),
         country=address.get("country")
     )
     vehicle.remote_services.trigger_send_poi(poi_data)

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -57,7 +57,7 @@ class PointOfInterest:
                  additional_info: str = None, street: str = None, city: str = None,
                  postal_code: str = None, country: str = None, website: str = None,
                  phone_numbers: [str] = None):
-        """Create a PointOfInterest with attributes in attributes in camelCase as required by the API.
+        """Create a PointOfInterest with attributes in camelCase as required by the API.
 
         :arg lat: latitude of the POI
         :arg lon: longitude of the POI

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -54,34 +54,34 @@ class PointOfInterest:
 
     # pylint: disable=too-many-arguments
     def __init__(self, lat: float, lon: float, name: str = None,
-                 additionalInfo: str = None, street: str = None, city: str = None,
-                 postalCode: str = None, country: str = None, website: str = None,
-                 phoneNumbers: [str] = None):
-        """Constructor.
+                 additional_info: str = None, street: str = None, city: str = None,
+                 postal_code: str = None, country: str = None, website: str = None,
+                 phone_numbers: [str] = None):
+        """Create a PointOfInterest with attributes in attributes in camelCase as required by the API.
 
-        :arg latitude: latitude of the POI
-        :arg longitude: longitude of the POI
+        :arg lat: latitude of the POI
+        :arg lon: longitude of the POI
         :arg name: name of the POI (Optional)
-        :arg additionalInfo: additional text shown below the address (Optional)
+        :arg additional_info: additional text shown below the address (Optional)
         :arg street: street with house number of the POI (Optional)
         :arg city: city of the POI (Optional)
-        :arg postalCode: zip code of the POI (Optional)
+        :arg postal_code: zip code of the POI (Optional)
         :arg country: country of the POI (Optional)
         :arg website: website of the POI (Optional)
-        :arg phoneNumbers: List of phone numbers of the POI (Optional)
+        :arg phone_numbers: List of phone numbers of the POI (Optional)
         """
         # pylint: disable=invalid-name
         self.lat = lat  # type: float
         self.lon = lon  # type: float
         self.name = name  # type: str
-        self.additionalInfo = additionalInfo if additionalInfo is not None \
+        self.additionalInfo = additional_info if additional_info is not None \
             else 'Sent with ♥ by bimmer_connected'  # type: str
         self.street = street  # type: str
         self.city = city  # type: str
-        self.postalCode = postalCode  # type: str
+        self.postalCode = postal_code  # type: str
         self.country = country  # type: str
         self.website = website  # type: str
-        self.phoneNumbers = phoneNumbers  # type: list[str]
+        self.phoneNumbers = phone_numbers  # type: list[str]
 
 
 class Message:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -88,13 +88,13 @@ POI_DATA = {
     "lat": 37.4028943,
     "lon": -121.9700289,
     "name": "49ers",
-    "additionalInfo": "Hi Sam",
+    "additional_info": "Hi Sam",
     "street": "4949 Marie P DeBartolo Way",
     "city": "Santa Clara",
-    "postalCode": "CA 95054",
+    "postal_code": "CA 95054",
     "country": "United States",
     "website": "https://www.49ers.com/",
-    "phoneNumbers": ["+1 408-562-4949"]
+    "phone_numbers": ["+1 408-562-4949"]
 }
 
 POI_REQUEST = {

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -130,10 +130,10 @@ class TestRemoteServices(unittest.TestCase):
     def test_parsing_of_poi_all_attributes(self):
         """Check that a PointOfInterest can be constructed using all attributes."""
         poi = PointOfInterest(POI_DATA["lat"], POI_DATA["lon"], name=POI_DATA["name"],
-                              additionalInfo=POI_DATA["additionalInfo"], street=POI_DATA["street"],
-                              city=POI_DATA["city"], postalCode=POI_DATA["postalCode"],
+                              additional_info=POI_DATA["additional_info"], street=POI_DATA["street"],
+                              city=POI_DATA["city"], postal_code=POI_DATA["postal_code"],
                               country=POI_DATA["country"], website=POI_DATA["website"],
-                              phoneNumbers=POI_DATA["phoneNumbers"])
+                              phone_numbers=POI_DATA["phone_numbers"])
         msg = Message.from_poi(poi)
         self.assertEqual(msg.as_server_request, POI_REQUEST["all"])
 


### PR DESCRIPTION
To comply with and enable the changes in home-assistant/core#33484, we need `snake_case` instead of `camelCase` parameters for `PointOfInterest`.

This is a potential **breaking change** for everybody who used `PointOfInterest` or `message.from_poi()` directly.
The cli parameters are interally adjusted and keep working.