### PR TITLE
Use pbr for build & versioning

### DIFF
--- a/bimmer_connected/__init__.py
+++ b/bimmer_connected/__init__.py
@@ -1,1 +1,5 @@
 """Init file for bimmer_connected."""
+
+import pkg_resources  # part of setuptools
+
+__version__ = pkg_resources.get_distribution("bimmer_connected").version

--- a/bimmer_connected/version.py
+++ b/bimmer_connected/version.py
@@ -1,3 +1,0 @@
-"""Version information."""
-
-__version__ = '0.7.5'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2018-2020, m1n3rva, gerard33'
 author = 'rikroe'
 
 # The short X.Y version
-version = const.__version__
+# version = const.__version__
 # The full version, including alpha/beta/rc tags
 # release = const.__version__
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-from bimmer_connected import version as const
-
 # -- Project information -----------------------------------------------------
 
 project = 'bimmer_connected'
@@ -27,7 +25,7 @@ author = 'rikroe'
 # The short X.Y version
 version = const.__version__
 # The full version, including alpha/beta/rc tags
-release = const.__version__
+# release = const.__version__
 
 # -- General configuration ---------------------------------------------------
 
@@ -39,6 +37,7 @@ release = const.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'pbr.sphinxext',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ sphinx
 sphinx-autobuild
 sphinx_rtd_theme
 sphinx-argparse
+pbr

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,34 @@
+[metadata]
+name = bimmer_connected
+author = gerard33
+author-email = bietenbak@yahoo.com
+summary = Library to read data from the BMW Connected Drive portal
+description-file = README.rst
+description-content-type = text/x-rst; charset=UTF-8
+python_requires = >= 3.5
+home-page = https://github.com/bimmerconnected/bimmer_connected
+project_urls =
+    Bug Tracker = https://github.com/bimmerconnected/bimmer_connected/issues
+    Documentation = https://bimmer-connected.readthedocs.io/en/latest/
+    Source Code = https://github.com/bimmerconnected/bimmer_connected
+license = Apache-2
+classifier =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Developers
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+keywords =
+    BMW
+    Connected Drive
+    home automation
+
+[files]
+packages =
+    bimmer_connected
+
+[entry_points]
+console_scripts =
+    bimmerconnected = bimmer_connected.cli:main

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,7 @@
 """Python package description."""
-from setuptools import setup, find_packages
-
-from bimmer_connected.version import __version__ as version
-
-def readme():
-    """Load the readme file."""
-    with open('README.rst') as readme_file:
-        return readme_file.read()
+from setuptools import setup
 
 setup(
-    name="bimmer_connected",
-    version=version,
-    author="gerard33",
-    author_email="bietenbak@yahoo.com",
-    description="Library to read data from the BMW Connected Drive portal",
-    long_description=readme(),
-    long_description_content_type="text/x-rst",
-    url="https://github.com/bimmerconnected/bimmer_connected",
-    packages=['bimmer_connected'],
-    install_requires=[
-        'requests', 'typing>=3,<4;python_version<"3.5"'
-    ],
-    keywords='BMW Connected Drive home automation',
-    zip_safe=False,
-    extras_require={
-        'testing': ['pytest']
-    },
-    entry_points={
-        'console_scripts': [
-            'bimmerconnected=bimmer_connected.cli:main'
-        ],
-    },
-    license='Apache 2.0',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ],
+    setup_requires=['pbr'],
+    pbr=True,
 )


### PR DESCRIPTION
This PR adds [pbr](https://docs.openstack.org/pbr/latest/index.html) for automatically setting the correct library version based on the latest `git tag`. 

- if the latest commit also is referenced by a __tag__, the tag is taken as version number, i.e. `0.7.5`.
- if the latest commit has no tag, the main version will point to the latest **tag**, and then dev**number of commits after the tag**, i.e. `0.7.5dev1`.

This PR is an alternative to #172 which does not need any additional packaged files.

Although not tested with Github Actions, it should work flawlessly as well. If executed on a repository with a tag on the last commit (like we do when creating releases), running `python setup.py sdist bdist_wheel` (such as in the Action) creates the correctly versioned archives.