### PR TITLE
General enhancement of docs, add cli documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,31 +11,51 @@
 .. image:: https://coveralls.io/repos/github/bimmerconnected/bimmer_connected/badge.svg?branch=master
     :target: https://coveralls.io/github/bimmerconnected/bimmer_connected?branch=master
 
-bimmer_connected
-================
+.. raw:: html
+
+   <h1>bimmer_connected</h1>
 
 This is a simple library to query and control the status of your BMW or Mini vehicle from
 the Connected Drive portal.
 
-See :code:`bimmerconnected` for usage instruction or the
-`API Documentation <http://bimmer-connected.readthedocs.io/en/latest/>`_.
 
-This library is written to include it in Home Assistant.
+Installation
+============
+Just install the latest release from `PyPI <https://pypi.org/project/bimmer-connected/>`_ 
+using :code:`pip install bimmer_connected`.
+
+Alteratively, clone the project and execute :code:`pip install .` to install the current 
+:code:`master` branch.
+
+Usage
+=====
+After installation, execute :code:`bimmerconnected` from command line for usage instruction
+or see the full `CLI documentation <http://bimmer-connected.readthedocs.io/en/latest/#cli>`_.
+
+The description of the :code:`modules` can be found in the `module documentation 
+<http://bimmer-connected.readthedocs.io/en/latest/#module>`_.
+
+This library is written to include it in `Home Assistant <https://www.home-assistant.io>`_.
 
 
 Compatibility
--------------
+=============
 This works with BMW (and Mini) vehicles with a Connected Drive account.
-So far it is tested on vehicles with a 'MGU', 'NBTEvo', 'EntryEvo', 'NBT', or 'EntryNav' navigation system.
-If you have any trouble with other navigation systems, please create an issue with your server responses (see next section).
+So far it is tested on vehicles with a 'MGU', 'NBTEvo', 'EntryEvo', 'NBT', or 'EntryNav'
+navigation system. If you have any trouble with other navigation systems, please create 
+an issue with your server responses (see next section).
 
-To use this library, your BMW (or Mini) must have the remote services enabled for your vehicle. You might need to book this in the Connected Drive/Mini Connected portal and this might cost some money. In addition to that you need to enable the Remote Services in your infotainment system in the vehicle.
+To use this library, your BMW (or Mini) must have the remote services enabled for your vehicle. 
+You might need to book this in the Connected Drive/Mini Connected portal and this might cost 
+some money. In addition to that you need to enable the Remote Services in your infotainment 
+system in the vehicle.
 
-Different models of vehicles and infotainment systems result in different types of attributes provided by the server. So the experience with the library will certaily vary across the different vehicle models.
+Different models of vehicles and infotainment systems result in different types of attributes
+provided by the server. So the experience with the library will certaily vary across the different 
+vehicle models.
 
 Data Contributions
-------------------
-
+==================
 If some features do not work for your vehicle, we would need the data
 returned form the server to analyse this and potentially extend the code.
 Different models and head unit generations lead to different responses from
@@ -53,10 +73,12 @@ If you want to contribute your data, perform the following steps:
 
 This will create a set of log files in the "vehicle_fingerprint" folder.
 Before sending the data to anyone please **check for any personal data**.
+
 The following attributes should be replaced with default values:
-* vin (=Vehicle Identification Number)
-* lat and lon (=GPS position)
-* licensePlate
+
+* :code:`vin` (Vehicle Identification Number)
+* :code:`lat` and :code:`lon` (GPS position)
+* :code:`licensePlate`
 
 Create a new
 `issue in bimmer_connected <https://github.com/bimmerconnected/bimmer_connected/issues>`_
@@ -64,7 +86,10 @@ and
 `add the files as attachment <https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/>`_
 to the issue.
 
-Please add your model and year to the title of the issue, to make it easier to organize. If you know the "chassis code" of your car, you can include that too. (For example, Googling "2017 BMW X5" will show a Wikipedia article entitled "BMW X5 (F15)". F15 is therefore the chassis code of the car.)
+Please add your model and year to the title of the issue, to make it easier to organize. 
+If you know the "chassis code" of your car, you can include that too. (For example, 
+googling "2017 BMW X5" will show a Wikipedia article entitled "BMW X5 (F15)". F15 is 
+therefore the chassis code of the car.)
 
 
 **Note:** We will then use this data as additional test cases. So we will publish
@@ -73,19 +98,15 @@ this as test cases for our library. If you do not want this, please
 let us know in advance.
 
 Code Contributions
-------------------
-Contributions are welcome! Please make sure that your code passed the "tox" checks.
+==================
+Contributions are welcome! Please make sure that your code passed the :code:`tox` checks. 
+We currently test against :code:`flake8`, :code:`pylint` and our own :code:`pytest` suite.
 And please add tests where it makes sense. The more the better.
 
-.. image:: https://travis-ci.org/bimmerconnected/bimmer_connected.svg?branch=master
-    :target: https://travis-ci.org/bimmerconnected/bimmer_connected
-.. image:: https://coveralls.io/repos/github/bimmerconnected/bimmer_connected/badge.svg?branch=master
-    :target: https://coveralls.io/github/bimmerconnected/bimmer_connected?branch=master
-
 Thank you
----------
+=========
 
-Thank you Christian, @m1n3rva, @kernelkraut, @robbz23 and @lawtancool for your research and contributions!
+Thank you Christian, @m1n3rva, @gerard33, @kernelkraut, @robbz23 and @lawtancool for your research and contributions!
 
 This library is basically a best-of of other similar solutions,
 yet none of them provided a ready to use library with a matching interface
@@ -98,9 +119,9 @@ to be used in Home Assistant and is available on pypi.
 Thank you for your great software!
 
 License
--------
+=======
 The bimmer_connected library is licensed under the Apache License 2.0.
 
 Disclaimer
-----------
+==========
 This library is not affiliated with or endorsed by BMW Group.

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,18 @@
+bimmer_connected
+================
+
+.. image:: https://badge.fury.io/py/bimmer-connected.svg
+    :target: https://pypi.org/project/bimmer-connected
 .. image:: https://pepy.tech/badge/bimmer-connected/week
     :target: https://pepy.tech/project/bimmer-connected/week
 .. image:: https://pepy.tech/badge/bimmer-connected/month
     :target: https://pepy.tech/project/bimmer-connected/month
 .. image:: https://pepy.tech/badge/bimmer-connected
     :target: https://pepy.tech/project/bimmer-connected
-.. image:: https://badge.fury.io/py/bimmer-connected.svg
-    :target: https://pypi.org/project/bimmer-connected
 .. image:: https://travis-ci.org/bimmerconnected/bimmer_connected.svg?branch=master
     :target: https://travis-ci.org/bimmerconnected/bimmer_connected
 .. image:: https://coveralls.io/repos/github/bimmerconnected/bimmer_connected/badge.svg?branch=master
     :target: https://coveralls.io/github/bimmerconnected/bimmer_connected?branch=master
-
-.. raw:: html
-
-   <h1>bimmer_connected</h1>
 
 This is a simple library to query and control the status of your BMW or Mini vehicle from
 the Connected Drive portal.
@@ -21,10 +20,10 @@ the Connected Drive portal.
 
 Installation
 ============
-Just install the latest release from `PyPI <https://pypi.org/project/bimmer-connected/>`_ 
-using :code:`pip install bimmer_connected`.
+:code:`bimmer_connected` requires **Python 3.6 or above** but should also run with Python 3.5. Just install the latest release from `PyPI <https://pypi.org/project/bimmer-connected/>`_ 
+using :code:`pip3 install --upgrade bimmer_connected`. 
 
-Alteratively, clone the project and execute :code:`pip install .` to install the current 
+Alteratively, clone the project and execute :code:`pip install -e .` to install the current 
 :code:`master` branch.
 
 Usage
@@ -35,7 +34,7 @@ or see the full `CLI documentation <http://bimmer-connected.readthedocs.io/en/la
 The description of the :code:`modules` can be found in the `module documentation 
 <http://bimmer-connected.readthedocs.io/en/latest/#module>`_.
 
-This library is written to include it in `Home Assistant <https://www.home-assistant.io>`_.
+This library is written to be included in `Home Assistant <https://www.home-assistant.io/integrations/bmw_connected_drive/>`_.
 
 
 Compatibility
@@ -72,9 +71,9 @@ If you want to contribute your data, perform the following steps:
     bimmerconnected fingerprint <username> <password> <region>
 
 This will create a set of log files in the "vehicle_fingerprint" folder.
-Before sending the data to anyone please **check for any personal data**.
+Before sending the data to anyone please **check for any personal data** such as **dealer name** or **country**. 
 
-The following attributes should be replaced with default values:
+The following attributes are by default replaced with anonymized values:
 
 * :code:`vin` (Vehicle Identification Number)
 * :code:`lat` and :code:`lon` (GPS position)

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -18,7 +18,7 @@ FINGERPRINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'vehicle_fingerprint')
 
 
-def main() -> None:
+def main_parser() -> argparse.ArgumentParser:
     """Main function."""
     logging.basicConfig(level=logging.DEBUG)
 
@@ -78,8 +78,7 @@ def main() -> None:
     message_parser.add_argument('subject', help='(optional) message subject', nargs='?')
     message_parser.set_defaults(func=send_message)
 
-    args = parser.parse_args()
-    args.func(args)
+    return parser
 
 
 def get_status(args) -> None:
@@ -216,6 +215,12 @@ def _add_position_arguments(parser: argparse.ArgumentParser):
     parser.add_argument('lng', type=float, nargs='?', const=0.0,
                         help='optional: your gps longitude (as float)')
     parser.set_defaults(func=get_status)
+
+
+def main():
+    parser = main_parser()
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == '__main__':

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -17,39 +17,41 @@ from bimmer_connected.vehicle import VehicleViewDirection
 FINGERPRINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'vehicle_fingerprint')
 
+TEXT_VIN = 'Vehicle Identification Number'
+
 
 def main_parser() -> argparse.ArgumentParser:
     """Creates the ArgumentParser with all relevant subparsers."""
     logging.basicConfig(level=logging.DEBUG)
 
-    parser = argparse.ArgumentParser(description='demo script to show usage of the bimmer_connected library')
+    parser = argparse.ArgumentParser(description='A simple executable to use and test the library.')
     subparsers = parser.add_subparsers(dest='cmd')
     subparsers.required = True
 
-    status_parser = subparsers.add_parser('status', description='get current status of the vehicle')
+    status_parser = subparsers.add_parser('status', description='Get the current status of the vehicle.')
     _add_default_arguments(status_parser)
     _add_position_arguments(status_parser)
 
-    fingerprint_parser = subparsers.add_parser('fingerprint', description='save a vehicle fingerprint')
+    fingerprint_parser = subparsers.add_parser('fingerprint', description='Save a vehicle fingerprint.')
     _add_default_arguments(fingerprint_parser)
     _add_position_arguments(fingerprint_parser)
     fingerprint_parser.set_defaults(func=fingerprint)
 
-    flash_parser = subparsers.add_parser('lightflash', description='flash the vehicle lights')
+    flash_parser = subparsers.add_parser('lightflash', description='Flash the vehicle lights.')
     _add_default_arguments(flash_parser)
-    flash_parser.add_argument('vin', help='vehicle identification number')
+    flash_parser.add_argument('vin', help=TEXT_VIN)
     flash_parser.set_defaults(func=light_flash)
 
-    image_parser = subparsers.add_parser('image', description='download a vehicle image')
+    image_parser = subparsers.add_parser('image', description='Download a vehicle image.')
     _add_default_arguments(image_parser)
-    image_parser.add_argument('vin', help='vehicle identification number')
+    image_parser.add_argument('vin', help=TEXT_VIN)
     image_parser.set_defaults(func=image)
 
-    sendpoi_parser = subparsers.add_parser('sendpoi', description='send a point of interest to the vehicle')
+    sendpoi_parser = subparsers.add_parser('sendpoi', description='Send a point of interest to the vehicle.')
     _add_default_arguments(sendpoi_parser)
-    sendpoi_parser.add_argument('vin', help='vehicle identification number')
-    sendpoi_parser.add_argument('latitude', help='latitude of the POI', type=float)
-    sendpoi_parser.add_argument('longitude', help='longitude of the POI', type=float)
+    sendpoi_parser.add_argument('vin', help=TEXT_VIN)
+    sendpoi_parser.add_argument('latitude', help='Latitude of the POI', type=float)
+    sendpoi_parser.add_argument('longitude', help='Longitude of the POI', type=float)
     sendpoi_parser.add_argument('--name', help='(optional, display only) Name of the POI', nargs='?', default=None)
     sendpoi_parser.add_argument('--street', help='(optional, display only) Street & House No. of the POI',
                                 nargs='?', default=None)
@@ -61,21 +63,21 @@ def main_parser() -> argparse.ArgumentParser:
     sendpoi_parser.set_defaults(func=send_poi)
 
     sendpoi_from_address_parser = subparsers.add_parser('sendpoi_from_address',
-                                                        description=('send a point of interest from a street address'
-                                                                     ' to the vehicle'))
+                                                        description=('Send a point of interest parsed from a'
+                                                                     ' street address to the vehicle.'))
     _add_default_arguments(sendpoi_from_address_parser)
-    sendpoi_from_address_parser.add_argument('vin', help='vehicle identification number')
+    sendpoi_from_address_parser.add_argument('vin', help=TEXT_VIN)
     sendpoi_from_address_parser.add_argument('-n', '--name', help='(optional, display only) Name of the POI',
                                              nargs='?', default=None)
     sendpoi_from_address_parser.add_argument('-a', '--address', nargs='+',
-                                             help="address ('street, city, zip, country' etc)")
+                                             help="Address (e.g. 'Street 17, city, zip, country')")
     sendpoi_from_address_parser.set_defaults(func=send_poi_from_address)
 
-    message_parser = subparsers.add_parser('sendmessage', description='send a text message to the vehicle')
+    message_parser = subparsers.add_parser('sendmessage', description='Send a text message to the vehicle.')
     _add_default_arguments(message_parser)
-    message_parser.add_argument('vin', help='vehicle identification number')
-    message_parser.add_argument('text', help='text to be sent')
-    message_parser.add_argument('subject', help='(optional) message subject', nargs='?')
+    message_parser.add_argument('vin', help=TEXT_VIN)
+    message_parser.add_argument('text', help='Text to be sent.')
+    message_parser.add_argument('subject', help='(optional) Message subject', nargs='?')
     message_parser.set_defaults(func=send_message)
 
     return parser
@@ -95,10 +97,10 @@ def get_status(args) -> None:
 
     for vehicle in account.vehicles:
         print('VIN: {}'.format(vehicle.vin))
-        print('mileage: {}'.format(vehicle.state.mileage))
-        print('vehicle properties:')
+        print('Mileage: {}'.format(vehicle.state.mileage))
+        print('Vehicle properties:')
         print(json.dumps(vehicle.attributes, indent=4))
-        print('vehicle status:')
+        print('Vehicle status:')
         print(json.dumps(vehicle.state.attributes, indent=4))
 
 
@@ -203,7 +205,7 @@ def send_message(args) -> None:
 
 def _add_default_arguments(parser: argparse.ArgumentParser):
     """Add the default arguments username, password, region to the parser."""
-    parser.add_argument('username', help='Connected Drive user name')
+    parser.add_argument('username', help='Connected Drive username')
     parser.add_argument('password', help='Connected Drive password')
     parser.add_argument('region', choices=valid_regions(), help='Region of the Connected Drive account')
 
@@ -211,9 +213,9 @@ def _add_default_arguments(parser: argparse.ArgumentParser):
 def _add_position_arguments(parser: argparse.ArgumentParser):
     """Add the lat and lng attributes to the parser."""
     parser.add_argument('lat', type=float, nargs='?', const=0.0,
-                        help='optional: your gps latitide (as float)')
+                        help='(optional) Your current GPS latitude (as float)')
     parser.add_argument('lng', type=float, nargs='?', const=0.0,
-                        help='optional: your gps longitude (as float)')
+                        help='(optional) Your current GPS longitude (as float)')
     parser.set_defaults(func=get_status)
 
 

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -19,7 +19,7 @@ FINGERPRINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 
 def main_parser() -> argparse.ArgumentParser:
-    """Main function."""
+    """Creates the ArgumentParser with all relevant subparsers."""
     logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser(description='demo script to show usage of the bimmer_connected library')
@@ -218,6 +218,7 @@ def _add_position_arguments(parser: argparse.ArgumentParser):
 
 
 def main():
+    """Main function."""
     parser = main_parser()
     args = parser.parse_args()
     args.func(args)

--- a/docs/source/api/account.rst
+++ b/docs/source/api/account.rst
@@ -1,8 +1,8 @@
 .. _bimmer_connected_module:
 
-bimmer_connected.account
-------------------------
-
+:mod:`bimmer_connected.account`
+===============================
+ 
 .. automodule:: bimmer_connected.account
     :members:
     :undoc-members:

--- a/docs/source/api/country_selector.rst
+++ b/docs/source/api/country_selector.rst
@@ -1,7 +1,7 @@
 .. _country_selector_module:
 
-bimmer_connected.country_selector
----------------------------------
+:mod:`bimmer_connected.country_selector`
+========================================
 
 .. automodule:: bimmer_connected.country_selector
     :members:

--- a/docs/source/api/remove_services.rst
+++ b/docs/source/api/remove_services.rst
@@ -1,7 +1,7 @@
 .. _remote_services_module:
 
-bimmer_connected.remote_services
---------------------------------
+:mod:`bimmer_connected.remote_services`
+=======================================
 
 .. automodule:: bimmer_connected.remote_services
     :members:

--- a/docs/source/api/state.rst
+++ b/docs/source/api/state.rst
@@ -1,7 +1,7 @@
 .. _state_module:
 
-bimmer_connected.state
-----------------------
+:mod:`bimmer_connected.state`
+=============================
 
 .. automodule:: bimmer_connected.state
     :members:

--- a/docs/source/api/vehicle.rst
+++ b/docs/source/api/vehicle.rst
@@ -1,7 +1,7 @@
 .. _vehicle_module:
 
-bimmer_connected.vehicle
-------------------------
+:mod:`bimmer_connected.vehicle`
+===============================
 
 .. automodule:: bimmer_connected.vehicle
     :members:

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,9 @@
+.. _cli_module:
+
+:mod:`bimmerconnected`
+======================
+
+.. argparse::
+   :module: bimmer_connected.cli
+   :func: main_parser
+   :prog: bimmerconnected

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = '2018-2020, m1n3rva, gerard33'
 author = 'rikroe'
 
 # The short X.Y version
-# version = const.__short_version__
+version = const.__version__
 # The full version, including alpha/beta/rc tags
 release = const.__version__
 
@@ -88,7 +88,9 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'display_version': True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,8 +21,8 @@ from bimmer_connected import version as const
 # -- Project information -----------------------------------------------------
 
 project = 'bimmer_connected'
-copyright = '2018, m1n3rva'
-author = 'm1n3rva'
+copyright = '2018-2020, m1n3rva, gerard33'
+author = 'rikroe'
 
 # The short X.Y version
 # version = const.__short_version__
@@ -44,6 +44,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
+    'sphinxarg.ext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -79,7 +81,8 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,24 @@
-.. bimmer_connected documentation master file, created by
-   sphinx-quickstart on Sun Feb 18 13:35:12 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 .. include:: ../../README.rst
 
-API documentation
-=================
 .. toctree::
+   :caption: bimmer_connected
+   :titlesonly: 
+
+   readme
+
+
+.. toctree::
+   :caption: CLI documentation
+   :name: cli
+   :maxdepth: 2
+   :glob:
+
+   cli
+
+
+.. toctree::
+   :caption: Module documentation
+   :name: module
    :maxdepth: 2
    :glob:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,7 @@
 .. include:: ../../README.rst
 
 .. toctree::
-   :caption: bimmer_connected
-   :titlesonly: 
+   :caption: Readme
 
    readme
 

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../../README.rst

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,5 @@ pylint
 flake8
 sphinx
 sphinx-autobuild
+sphinx_rtd_theme
+sphinx-argparse


### PR DESCRIPTION
Fixes #160.

Through the issue I had another view at our docs. This resulted in some changes to make them easier to read and contain more information: 

- Change theme from `alabaster` to `sphinx_rtd_theme`
- Include a documentation for `cli`
- For the automated parsing of `cli`, the `ArgumentParser` itself had to be refactored into its own function
- Improve navigation on the docs
- Improve `README.rst` to better integrate into docs and provide better information in GitHub
