### PR TITLE
Use home dir for fingerprint data

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -12,7 +12,6 @@ import datetime
 import logging
 import pathlib
 import urllib
-import os
 import json
 from threading import Lock
 from typing import Callable, List

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -10,6 +10,7 @@ This library is not affiliated with or endorsed by BMW Group.
 
 import datetime
 import logging
+import pathlib
 import urllib
 import os
 import json
@@ -42,7 +43,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, username: str, password: str, region: Regions, log_responses: str = None,
+    def __init__(self, username: str, password: str, region: Regions, log_responses: pathlib.Path = None,
                  retries_on_500_error: int = 5) -> None:
         self._region = region
         self._server_url = None
@@ -183,8 +184,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
         output_path = None
         count = 0
 
-        while output_path is None or os.path.exists(output_path):
-            output_path = os.path.join(self._log_responses, '{}_{}.txt'.format(logfilename, count))
+        while output_path is None or output_path.exists():
+            output_path = self._log_responses / '{}_{}.txt'.format(logfilename, count)
             count += 1
 
         with open(output_path, 'w') as logfile:

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -10,12 +10,11 @@ import sys
 
 import requests
 
+from pathlib import Path
+
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name, valid_regions
 from bimmer_connected.vehicle import VehicleViewDirection
-
-FINGERPRINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               'vehicle_fingerprint')
 
 TEXT_VIN = 'Vehicle Identification Number'
 
@@ -106,9 +105,8 @@ def get_status(args) -> None:
 
 def fingerprint(args) -> None:
     """Save the vehicle fingerprint."""
-    time_str = time.strftime("%Y-%m-%d_%H-%M-%S")
-    time_dir = os.path.join(FINGERPRINT_DIR, time_str)
-    os.makedirs(time_dir)
+    time_dir = Path.home() / 'vehicle_fingerprint' / time.strftime("%Y-%m-%d_%H-%M-%S")
+    time_dir.mkdir(parents=True)
 
     account = ConnectedDriveAccount(args.username, args.password, get_region_from_name(args.region),
                                     log_responses=time_dir)

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -4,13 +4,12 @@
 import argparse
 import logging
 import json
-import os
 import time
 import sys
 
-import requests
-
 from pathlib import Path
+
+import requests
 
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.country_selector import get_region_from_name, valid_regions


### PR DESCRIPTION
This PR stores the data of a fingerprint command in the home dir. Currently it's written to the `/usr/` dir which is not logic and can give issues if the user doesn't have write rights for that dir.

It will now change to
On Linux -> `/home/username/vehicle_fingerprint/<date-time>`
On Windows -> `C:\Users\username\vehicle_fingerprint\<date-time>`

This PR replaces #118 as that one had some conflicts.