### PR TITLE
Add VEHICLE_FINDER remote service

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -40,6 +40,11 @@ def main_parser() -> argparse.ArgumentParser:
     flash_parser.add_argument('vin', help=TEXT_VIN)
     flash_parser.set_defaults(func=light_flash)
 
+    finder_parser = subparsers.add_parser('vehiclefinder', description='Update the vehicle GPS location.')
+    _add_default_arguments(finder_parser)
+    finder_parser.add_argument('vin', help=TEXT_VIN)
+    finder_parser.set_defaults(func=vehicle_finder)
+
     image_parser = subparsers.add_parser('image', description='Download a vehicle image.')
     _add_default_arguments(image_parser)
     image_parser.add_argument('vin', help=TEXT_VIN)
@@ -127,6 +132,18 @@ def light_flash(args) -> None:
         print('Error: Could not find vehicle for VIN "{}". Valid VINs are: {}'.format(args.vin, valid_vins))
         return
     status = vehicle.remote_services.trigger_remote_light_flash()
+    print(status.state)
+
+
+def vehicle_finder(args) -> None:
+    """Trigger the vehicle finder to locate it."""
+    account = ConnectedDriveAccount(args.username, args.password, get_region_from_name(args.region))
+    vehicle = account.get_vehicle(args.vin)
+    if not vehicle:
+        valid_vins = ", ".join(v.vin for v in account.vehicles)
+        print('Error: Could not find vehicle for VIN "{}". Valid VINs are: {}'.format(args.vin, valid_vins))
+        return
+    status = vehicle.remote_services.trigger_remote_vehicle_finder()
     print(status.state)
 
 

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -38,6 +38,7 @@ class ExecutionState(Enum):
 class _Services(Enum):
     """Enumeration of possible services to be executed."""
     REMOTE_LIGHT_FLASH = 'LIGHT_FLASH'
+    REMOTE_VEHICLE_FINDER = 'VEHICLE_FINDER'
     REMOTE_DOOR_LOCK = 'DOOR_LOCK'
     REMOTE_DOOR_UNLOCK = 'DOOR_UNLOCK'
     REMOTE_HORN = 'HORN_BLOW'
@@ -290,3 +291,15 @@ class RemoteServices:
                                           data=msg.as_server_request,
                                           post=True,
                                           expected_response=204)
+
+    def trigger_remote_vehicle_finder(self) -> RemoteServiceStatus:
+        """Trigger the vehicle finder.
+
+        A state update is triggered after this, as the location state of the vehicle changes.
+        """
+        _LOGGER.debug('Triggering remote vehicle finder')
+        # needs to be called via POST, GET is not working
+        self._trigger_remote_service(_Services.REMOTE_VEHICLE_FINDER, post=True)
+        result = self._block_until_done(_Services.REMOTE_VEHICLE_FINDER)
+        self._trigger_state_update()
+        return result

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -51,6 +51,7 @@ class TestRemoteServices(unittest.TestCase):
             ('DOOR_LOCK', 'trigger_remote_door_lock', True),
             ('DOOR_UNLOCK', 'trigger_remote_door_unlock', True),
             ('CLIMATE_NOW', 'trigger_remote_air_conditioning', True),
+            ('VEHICLE_FINDER', 'trigger_remote_vehicle_finder', True),
             ('HORN_BLOW', 'trigger_remote_horn', False),
             ('SEND_MESSAGE', 'trigger_send_message', False),
             ('SEND_POI', 'trigger_send_poi', False),


### PR DESCRIPTION
Fixes #182. Many thanks to @droneando for doing inital testing and development!

Adds `VEHICLE_FINDER` remote service to trigger an update of the vehicle position.
Can be called from anywhere, no GPS coordinates required for vehicles pre 7/2014.

Usage from HA requires an update to the component.