### PR TITLE
Fix tests after not breaking at old vehicles

### DIFF
--- a/test/test_state.py
+++ b/test/test_state.py
@@ -144,8 +144,9 @@ class TestState(unittest.TestCase):
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
             vehicle = account.get_vehicle(G31_VIN)
-            with self.assertRaises(IOError):
-                vehicle.state.update_data()
+
+            vehicle.state.update_data()
+            self.assertEqual(vehicle.state._attributes, {})
 
             backend_mock.setup_default_vehicles()
 


### PR DESCRIPTION
This fixes the tests after #187 was merged. My bad for not looking at the tests...

The old tests expected an Error if no vehicle status is found which is not the case anymore. This also fixes coverage.