### PR TITLE
Fix login issues in China

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -78,10 +78,10 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 "Connection": "Keep-Alive",
                 "Host": urllib.parse.urlparse(url).netloc,
                 "Accept-Encoding": "gzip",
-                "Authorization": "Basic ZDc2NmI1MzctYTY1NC00Y2JkLWEzZGMtMGNhNTY3MmQ3ZjhkOjE1"
-                                 "ZjY5N2Y2LWE1ZDUtNGNhZC05OWQ5LTNhMTViYzdmMzk3Mw==",
+                "Authorization": "Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGNEanli"
+                                 "TEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==",
                 "Credentials": "nQv6CqtxJuXWP74xf3CJwUEP:1zDHx6un4cDjybLENN3kyfumX2kEYigWPcQpdvDRpIBk7rOJ",
-                "User-Agent": "okhttp/3.12.2",
+                "User-Agent": "okhttp/2.60",
             }
 
             # we really need all of these parameters

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -19,7 +19,7 @@ import requests
 
 from bimmer_connected.country_selector import Regions, get_server_url, get_gcdm_oauth_endpoint
 from bimmer_connected.vehicle import ConnectedDriveVehicle
-from bimmer_connected.const import AUTH_URL, AUTH_URL_LEGACY, VEHICLES_URL, ERROR_CODE_MAPPING
+from bimmer_connected.const import AUTH_URL, VEHICLES_URL, ERROR_CODE_MAPPING
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,11 +68,15 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 return
 
             _LOGGER.debug('getting new oauth token')
+            url = AUTH_URL.format(
+                gcdm_oauth_endpoint=get_gcdm_oauth_endpoint(self._region)
+            )
+
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Content-Length": "124",
                 "Connection": "Keep-Alive",
-                "Host": "customer.bmwgroup.com" if self._region == Regions.REST_OF_WORLD else self.server_url,
+                "Host": urllib.parse.urlparse(url).netloc,
                 "Accept-Encoding": "gzip",
                 "Authorization": "Basic ZDc2NmI1MzctYTY1NC00Y2JkLWEzZGMtMGNhNTY3MmQ3ZjhkOjE1"
                                  "ZjY5N2Y2LWE1ZDUtNGNhZC05OWQ5LTNhMTViYzdmMzk3Mw==",
@@ -89,14 +93,8 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             }
 
             data = urllib.parse.urlencode(values)
-            if self._region == Regions.REST_OF_WORLD:
-                url = AUTH_URL.format(
-                    gcdm_oauth_endpoint=get_gcdm_oauth_endpoint(self._region)
-                )
-                expected_response_code = 200
-            else:
-                url = AUTH_URL_LEGACY.format(server=self.server_url)
-                expected_response_code = 200
+
+            expected_response_code = 200
             try:
                 response = self.send_request(url, data=data, headers=headers, allow_redirects=False,
                                              expected_response=expected_response_code, post=True)

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -1,7 +1,6 @@
 """URLs for different services and error code mapping."""
 
-AUTH_URL = 'https://customer.bmwgroup.com/{gcdm_oauth_endpoint}/token'
-AUTH_URL_LEGACY = 'https://{server}/gcdm/oauth/token'
+AUTH_URL = 'https://{gcdm_oauth_endpoint}/oauth/token'
 BASE_URL = 'https://{server}/webapi/v1'
 
 VEHICLES_URL = BASE_URL + '/user/vehicles'

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -22,9 +22,9 @@ _SERVER_URLS = {
 
 #: Mapping from regions to servers
 _GCDM_OAUTH_ENDPOINTS = {
-    Regions.NORTH_AMERICA: 'gcdm/usa/oauth',
-    Regions.REST_OF_WORLD: 'gcdm/oauth',
-    Regions.CHINA: 'gcdm/oauth'
+    Regions.NORTH_AMERICA: 'customer.bmwgroup.com/gcdm/usa',
+    Regions.REST_OF_WORLD: 'customer.bmwgroup.com/gcdm',
+    Regions.CHINA: 'customer.bmwgroup.cn/gcdm'
 }
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -132,14 +132,10 @@ class BackendMock:
         """Constructor."""
         self.last_request = []
         self.responses = [
-            MockResponse('https://.+/gcdm/oauth/token',
+            MockResponse('https://.+/gcdm/.*/?oauth/token',
                          headers=_AUTH_RESPONSE_HEADERS,
                          data_files=['G31_NBTevo/auth_response.json'],
                          status_code=200),
-            MockResponse('https://.+/gcdm/(.+/)?oauth/authenticate',
-                         headers=_AUTH_RESPONSE_HEADERS,
-                         data_files=['G31_NBTevo/auth_response.json'],
-                         status_code=302),
             MockResponse('https://.+/webapi/v1/user/vehicles$',
                          data_files=['vehicles.json']),
         ]

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -38,7 +38,7 @@ class TestAccount(unittest.TestCase):
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
             ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.NORTH_AMERICA)
             request = [r for r in backend_mock.last_request if 'oauth' in r.url][0]
-            self.assertEqual('b2vapi.bmwgroup.us', request.headers['Host'])
+            self.assertEqual('customer.bmwgroup.com', request.headers['Host'])
 
     def test_anonymize_data(self):
         """Test anonymization function."""

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -32,13 +32,22 @@ class TestAccount(unittest.TestCase):
             with self.assertRaises(IOError):
                 account.send_request('invalid_url')
 
-    def test_us_header(self):
+    def test_invalid_auth(self):
         """Test if the host is set correctly in the request."""
         backend_mock = BackendMock()
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
-            ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.NORTH_AMERICA)
+            with mock.patch('bimmer_connected.account.get_gcdm_oauth_endpoint') as mocked_endpoint:
+                mocked_endpoint().return_value = 'customer.bmwgroup.com/gcdm/invalid'
+                with self.assertRaises(OSError):
+                    ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.REST_OF_WORLD)
+
+    def test_china_header(self):
+        """Test if the host is set correctly in the request."""
+        backend_mock = BackendMock()
+        with mock.patch('bimmer_connected.account.requests', new=backend_mock):
+            ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.CHINA)
             request = [r for r in backend_mock.last_request if 'oauth' in r.url][0]
-            self.assertEqual('customer.bmwgroup.com', request.headers['Host'])
+            self.assertEqual('customer.bmwgroup.cn', request.headers['Host'])
 
     def test_anonymize_data(self):
         """Test anonymization function."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The changes in 0.7.8 lead to users in China (and probably North America) not being able to login anymore.
Apparently China uses older credentials than rest_of_world. However with the old credentials and the new API, at least china and rest_of_world are working (north_america should be working as well).

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #220 
- This PR is related to issue: #208 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
