### PR TITLE
Fix login for north_america and rest_of_world

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -17,7 +17,12 @@ from threading import Lock
 from typing import Callable, List
 import requests
 
-from bimmer_connected.country_selector import Regions, get_server_url, get_gcdm_oauth_endpoint
+from bimmer_connected.country_selector import (
+    Regions,
+    get_server_url,
+    get_gcdm_oauth_endpoint,
+    get_gcdm_oauth_authorization
+)
 from bimmer_connected.vehicle import ConnectedDriveVehicle
 from bimmer_connected.const import AUTH_URL, VEHICLES_URL, ERROR_CODE_MAPPING
 
@@ -78,11 +83,10 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 "Connection": "Keep-Alive",
                 "Host": urllib.parse.urlparse(url).netloc,
                 "Accept-Encoding": "gzip",
-                "Authorization": "Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGNEanli"
-                                 "TEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==",
                 "Credentials": "nQv6CqtxJuXWP74xf3CJwUEP:1zDHx6un4cDjybLENN3kyfumX2kEYigWPcQpdvDRpIBk7rOJ",
-                "User-Agent": "okhttp/2.60",
+                "User-Agent": "okhttp/3.12.2",
             }
+            headers.update(get_gcdm_oauth_authorization(self._region))
 
             # we really need all of these parameters
             values = {

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -15,16 +15,31 @@ class Regions(Enum):
 
 #: Mapping from regions to servers
 _SERVER_URLS = {
-    Regions.NORTH_AMERICA: 'b2vapi.bmwgroup.us',
-    Regions.REST_OF_WORLD: 'b2vapi.bmwgroup.com',
-    Regions.CHINA: 'b2vapi.bmwgroup.cn:8592'
+    Regions.NORTH_AMERICA: "b2vapi.bmwgroup.us",
+    Regions.REST_OF_WORLD: "b2vapi.bmwgroup.com",
+    Regions.CHINA: "b2vapi.bmwgroup.cn:8592",
 }
 
 #: Mapping from regions to servers
 _GCDM_OAUTH_ENDPOINTS = {
-    Regions.NORTH_AMERICA: 'b2vapi.bmwgroup.us/gcdm',
-    Regions.REST_OF_WORLD: 'customer.bmwgroup.com/gcdm',
-    Regions.CHINA: 'customer.bmwgroup.cn/gcdm'
+    Regions.NORTH_AMERICA: "b2vapi.bmwgroup.us/gcdm",
+    Regions.REST_OF_WORLD: "customer.bmwgroup.com/gcdm",
+    Regions.CHINA: "customer.bmwgroup.cn/gcdm",
+}
+
+_GCDM_OAUTH_AUTHORIZATION = {
+    Regions.NORTH_AMERICA: {
+        "Authorization": ("Basic ZDc2NmI1MzctYTY1NC00Y2JkLWEzZGMtMGNhNTY3MmQ3Zjh"
+                          "kOjE1ZjY5N2Y2LWE1ZDUtNGNhZC05OWQ5LTNhMTViYzdmMzk3Mw==")
+    },
+    Regions.REST_OF_WORLD: {
+        "Authorization": ("Basic ZDc2NmI1MzctYTY1NC00Y2JkLWEzZGMtMGNhNTY3MmQ3Zjh"
+                          "kOjE1ZjY5N2Y2LWE1ZDUtNGNhZC05OWQ5LTNhMTViYzdmMzk3Mw==")
+    },
+    Regions.CHINA: {
+        "Authorization": ("Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGN"
+                          "EanliTEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==")
+    },
 }
 
 
@@ -41,9 +56,11 @@ def get_region_from_name(name: str) -> Regions:
     for region_name, region in Regions.__members__.items():
         if name.lower() == region_name.lower():
             return region
-    raise ValueError('Unknown region {}. Valid regions are: {}'.format(
-        name,
-        ','.join(valid_regions())))
+    raise ValueError(
+        "Unknown region {}. Valid regions are: {}".format(
+            name, ",".join(valid_regions())
+        )
+    )
 
 
 def get_server_url(region: Regions) -> str:
@@ -54,3 +71,8 @@ def get_server_url(region: Regions) -> str:
 def get_gcdm_oauth_endpoint(region: Regions) -> str:
     """Get the url of the server for the region."""
     return _GCDM_OAUTH_ENDPOINTS[region]
+
+
+def get_gcdm_oauth_authorization(region: Regions) -> str:
+    """Get the url of the server for the region."""
+    return _GCDM_OAUTH_AUTHORIZATION[region]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
BMW changed the login secrets... Again... They did it a couple of weeks back, but reverted. 
We're now using the new secrets for `north_america` and `rest_of_world`, as `china` is still using the old secrets.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #250 
- This PR is related to issue: 

@gps1539, @deluxestyle, @nichwang88: Could you please test this?

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
