### PR TITLE
Do not throw exception for unknown status attributes

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -122,7 +122,7 @@ class VehicleState:
 
     def __getattr__(self, item):
         """Generic get function for all backend attributes."""
-        return self.vehicle_status.attributes[item]
+        return self.vehicle_status.attributes.get(item)
 
     @staticmethod
     def _parse_datetime(date_str: str) -> datetime.datetime:


### PR DESCRIPTION
Closes #257 👋

chargingInductivePositioning and fuelPercent do not seem to be supported anymore.
Requires confirmation as this only seems to be confirmed on hybrid plugin vehicles (Mini Cooper S E Countryman All4 and Bmw 330e iPerformance).


## Proposed change
Do not throw exception for unknown status attributes


## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)