### PR TITLE
Fix parkingLight issue

### DIFF
--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -183,7 +183,9 @@ class ConnectedDriveVehicle:
                        'check_control_messages', 'door_lock_state', 'internalDataTimeUTC',
                        'parking_lights', 'positionLight', 'last_update_reason', 'singleImmediateCharging']
             # required for existing Home Assistant binary sensors
-            result += ['lights_parking', 'lids', 'windows']
+            result += ['lids', 'windows']
+            if self.has_parking_light_state:
+                result += ['lights_parking']
         return result
 
     @property

--- a/bimmer_connected/vehicle_status.py
+++ b/bimmer_connected/vehicle_status.py
@@ -296,6 +296,11 @@ class VehicleStatus:  # pylint: disable=too-many-public-methods
         return ParkingLightState(self._state.attributes[SERVICE_STATUS]['parkingLight'])
 
     @property
+    def has_parking_light_state(self) -> bool:
+        """Return True if parking light is available."""
+        return 'parkingLight' in self._state.attributes[SERVICE_STATUS]
+
+    @property
     def are_parking_lights_on(self) -> bool:
         """Get status of parking lights.
 


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->

## Proposed change
Fix the issue with error codes in Home Assistant when no status of `parkingLight` is available via BMW ConnectedDrive.

I had the issue with my car now as well. Updated the code and tested it locally and works, the parking_light binary sensor is no longer made in HA when it's not available in the BMW ConnectedDrive api and so no more errors in the log.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163, #296
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
