### PR TITLE
Fix My BMW login for north_america

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -76,6 +76,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             try:
                 # We need a session for cross-request cookies
                 oauth_session = requests.Session()
+                oauth_settings = get_gcdm_oauth_authorization(self._region)
 
                 _LOGGER.debug("Authenticating against GCDM.")
                 authenticate_url = AUTH_URL.format(
@@ -83,19 +84,14 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 )
                 authenticate_headers = {
                     "Content-Type": "application/x-www-form-urlencoded",
-                    "Accept": "application/json, text/plain, */*",
-                    "User-Agent": (
-                        "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, "
-                        "like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1"
-                    ),
                 }
 
                 # we really need all of these parameters
                 oauth_base_values = {
-                    "client_id": "31c357a0-7a1d-4590-aa99-33b97244d048",
+                    "client_id": oauth_settings["authenticate"]["client_id"],
                     "response_type": "code",
                     "redirect_uri": "com.bmw.connected://oauth",
-                    "state": "cEG9eLAIi6Nv-aaCAniziE_B6FPoobva3qr5gukilYw",
+                    "state": oauth_settings["authenticate"]["state"],
                     "nonce": "login_nonce",
                     "scope": (
                         "openid profile email offline_access smacc vehicle_data perseus dlm svds cesim vsapi "
@@ -136,13 +132,11 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 )
                 token_headers = {
                     "Content-Type": "application/x-www-form-urlencoded",
-                    "Accept": "*/*",
-                    "User-Agent": "My%20BMW/8932 CFNetwork/978.0.7 Darwin/18.7.0",
+                    "Authorization": oauth_settings["token"]["Authorization"],
                 }
-                token_headers.update(get_gcdm_oauth_authorization(self._region))
                 token_values = {
                     "code": code,
-                    "code_verifier": "7PsmfPS5MpaNt0jEcPpi-B7M7u0gs1Nzw6ex0Y9pa-0",
+                    "code_verifier": oauth_settings["token"]["code_verifier"],
                     "redirect_uri": "com.bmw.connected://oauth",
                     "grant_type": "authorization_code",
                 }

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -22,23 +22,44 @@ _SERVER_URLS = {
 
 #: Mapping from regions to servers
 _GCDM_OAUTH_ENDPOINTS = {
-    Regions.NORTH_AMERICA: "customer.bmwgroup.com/gcdm/usa",
+    Regions.NORTH_AMERICA: "login.bmwusa.com/gcdm",
     Regions.REST_OF_WORLD: "customer.bmwgroup.com/gcdm",
     Regions.CHINA: "customer.bmwgroup.cn/gcdm",
 }
 
 _GCDM_OAUTH_AUTHORIZATION = {
     Regions.NORTH_AMERICA: {
-        "Authorization": ("Basic MzFjMzU3YTAtN2ExZC00NTkwLWFhOTktMzNiOTcyNDRkMDQ"
-                          "4OmMwZTMzOTNkLTcwYTItNGY2Zi05ZDNjLTg1MzBhZjY0ZDU1Mg==")
+        "token": {
+            "Authorization": ("Basic NTQzOTRhNGItYjZjMS00NWZlLWI3YjItOGZkM2FhOTI1M2F"
+                              "hOmQ5MmYzMWMwLWY1NzktNDRmNS1hNzdkLTk2NmY4ZjAwZTM1MQ=="),
+            "code_verifier": "KDarcVUpgymBDCgHDH0PwwMfzycDxu1joeklioOhwXA",
+        },
+        "authenticate": {
+            "client_id": "54394a4b-b6c1-45fe-b7b2-8fd3aa9253aa",
+            "state": "rgastJbZsMtup49-Lp0FMQ",
+        },
     },
     Regions.REST_OF_WORLD: {
-        "Authorization": ("Basic MzFjMzU3YTAtN2ExZC00NTkwLWFhOTktMzNiOTcyNDRkMDQ"
-                          "4OmMwZTMzOTNkLTcwYTItNGY2Zi05ZDNjLTg1MzBhZjY0ZDU1Mg==")
+        "token": {
+            "Authorization": ("Basic MzFjMzU3YTAtN2ExZC00NTkwLWFhOTktMzNiOTcyNDRkMDQ"
+                              "4OmMwZTMzOTNkLTcwYTItNGY2Zi05ZDNjLTg1MzBhZjY0ZDU1Mg=="),
+            "code_verifier": "7PsmfPS5MpaNt0jEcPpi-B7M7u0gs1Nzw6ex0Y9pa-0",
+        },
+        "authenticate": {
+            "client_id": "31c357a0-7a1d-4590-aa99-33b97244d048",
+            "state": "cEG9eLAIi6Nv-aaCAniziE_B6FPoobva3qr5gukilYw",
+        },
     },
     Regions.CHINA: {
-        "Authorization": ("Basic MzFjMzU3YTAtN2ExZC00NTkwLWFhOTktMzNiOTcyNDRkMDQ"
-                          "4OmMwZTMzOTNkLTcwYTItNGY2Zi05ZDNjLTg1MzBhZjY0ZDU1Mg==")
+        "token": {
+            "Authorization": ("Basic MzFjMzU3YTAtN2ExZC00NTkwLWFhOTktMzNiOTcyNDRkMDQ"
+                              "4OmMwZTMzOTNkLTcwYTItNGY2Zi05ZDNjLTg1MzBhZjY0ZDU1Mg=="),
+            "code_verifier": "",
+        },
+        "authenticate": {
+            "client_id": None,
+            "state": None,
+        },
     },
 }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Again thanks to @TA2k, login for `north_america` should be fixed now.

I cannot verify that the code actually works as calling `https://b2vapi.bmwgroup.us/webapi/v1/user/vehicles` returns a 500 internal server error without error messages.
This might be due to my account in north_america not having any cars assigned.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes (partly) #298 
- This PR is related to issue: #299

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
