### PR TITLE
Fix remote services in rest_of_world

### DIFF
--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -8,8 +8,14 @@ BASE_URL_LEGACY = 'https://{server}/api/vehicle'
 VEHICLES_URL = BASE_URL + '/user/vehicles'
 VEHICLE_VIN_URL = VEHICLES_URL + '/{vin}'
 VEHICLE_STATUS_URL = VEHICLE_VIN_URL + '/status'
+
 REMOTE_SERVICE_STATUS_URL = VEHICLE_VIN_URL + '/serviceExecutionStatus?serviceType={service_type}'
 REMOTE_SERVICE_URL = VEHICLE_VIN_URL + "/executeService"
+
+REMOTE_SERVICE_V2_BASE_URL = 'https://{server}/eadrax-vrccs/v2/presentation/remote-commands/'
+REMOTE_SERVICE_V2_URL = REMOTE_SERVICE_V2_BASE_URL + '/{vin}/{service_type}'
+REMOTE_SERVICE_V2_STATUS_URL = VEHICLE_VIN_URL + '/serviceExecutionHistory'
+
 VEHICLE_IMAGE_URL = VEHICLE_VIN_URL + "/image?width={width}&height={height}&view={view}"
 VEHICLE_POI_URL = VEHICLE_VIN_URL + '/sendpoi'
 VEHICLE_STATISTICS_URL = VEHICLE_VIN_URL + '/statistics'

--- a/bimmer_connected/country_selector.py
+++ b/bimmer_connected/country_selector.py
@@ -20,6 +20,12 @@ _SERVER_URLS = {
     Regions.CHINA: "b2vapi.bmwgroup.cn:8592",
 }
 
+_EADRAX_URLS = {
+    Regions.NORTH_AMERICA: "not-known.bmwusa.com",
+    Regions.REST_OF_WORLD: "cocoapi.bmwgroup.com",
+    Regions.CHINA: "myprofile.bmw.com.cn",
+}
+
 #: Mapping from regions to servers
 _GCDM_OAUTH_ENDPOINTS = {
     Regions.NORTH_AMERICA: "login.bmwusa.com/gcdm",
@@ -87,6 +93,11 @@ def get_region_from_name(name: str) -> Regions:
 def get_server_url(region: Regions) -> str:
     """Get the url of the server for the region."""
     return _SERVER_URLS[region]
+
+
+def get_server_url_v2(region: Regions) -> str:
+    """Get the url of the server for the region."""
+    return _EADRAX_URLS[region]
 
 
 def get_gcdm_oauth_endpoint(region: Regions) -> str:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Thanks to the amazing work of @TA2k, I was able to adjust to the new URLs and requests required for the new remote services API.
Some considerations:
- It seems only actual remote services have changed, but you never know how long other services are available
- This change is for `rest_of_world` only. Not sure if `north_america` uses the same type of API (and the host is currently unkown). `china` we're still not able to reproduce the login unfortunately.

## Type of change
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #309
- This PR is related to issue: https://github.com/home-assistant/core/issues/53977, https://github.com/home-assistant/core/issues/54524, https://github.com/bimmerconnected/bimmer_connected/discussions/273

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
