### PR TITLE
Fix `charging_end_time` by sending local time in milliseconds

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -381,7 +381,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
                 headers=self.request_header(brand),
                 params={
                     "apptimezone": self.utcdiff,
-                    "appDateTime": datetime.datetime.utcnow().timestamp(),
+                    "appDateTime": int(datetime.datetime.now().timestamp()*1000),
                     "tireGuardMode": "ENABLED"},
                 logfilename="vehicles_v2_{}".format(brand.value),
             )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Double checked the logs and found that the BMW API expects the timestamp in **milliseconds local time** instead of **seconds UTC**.
When trying this out against the BMW API, the times are changing massively, probably solving the issues with the wrong time being reported by the API.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #353, https://github.com/bimmerconnected/ha_custom_component/issues/12

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
