### PR TITLE
Fix login unauthorized

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -39,6 +39,7 @@ from bimmer_connected.country_selector import (
     get_server_url
 )
 from bimmer_connected.utils import (
+    RetrySession,
     create_s256_code_challenge,
     generate_token
 )
@@ -115,7 +116,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
         """Login to Rest of World and North America."""
         try:
             # We need a session for cross-request cookies
-            oauth_session = requests.Session()
+            oauth_session = RetrySession(status_forcelist=[401], allowed_methods=frozenset(["GET", "POST"]))
             r_oauth_settings = oauth_session.get(
                 OAUTH_CONFIG_URL.format(server=self.server_url),
                 headers={
@@ -137,6 +138,11 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             authenticate_url = AUTH_URL.format(gcdm_base_url=oauth_settings["gcdmBaseUrl"])
             authenticate_headers = {
                 "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": "https://customer.bmwgroup.com/oneid/",
+                "User-Agent": (
+                    "Mozilla/5.0 (Linux; Android 7.1.2; One) AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/95.0.4638.74 Mobile Safari/537.36"
+                ),
             }
 
             # we really need all of these parameters

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -42,6 +42,8 @@ from bimmer_connected.country_selector import (
 )
 from bimmer_connected.vehicle import CarBrand, ConnectedDriveVehicle
 
+VALID_UNTIL_OFFSET = datetime.timedelta(seconds=10)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -205,7 +207,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
             response_json = response.json()
 
             expiration_time = int(response_json["expires_in"])
-            expires_at = current_utc_time + datetime.timedelta(seconds=expiration_time)
+            expires_at = current_utc_time + datetime.timedelta(seconds=expiration_time) - VALID_UNTIL_OFFSET
 
             return {
                 "access_token": response_json["access_token"],
@@ -253,7 +255,7 @@ class ConnectedDriveAccount:  # pylint: disable=too-many-instance-attributes
 
             return {
                 "access_token": response_json["access_token"],
-                "expires_at": datetime.datetime.utcfromtimestamp(decoded_token["exp"])
+                "expires_at": datetime.datetime.utcfromtimestamp(decoded_token["exp"]) - VALID_UNTIL_OFFSET
             }
         except HTTPError as ex:
             try:

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -10,7 +10,7 @@ import random
 import string
 import sys
 from abc import ABC
-from typing import OrderedDict
+from collections import OrderedDict
 
 import requests
 from requests.adapters import HTTPAdapter

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -10,6 +10,11 @@ import random
 import string
 import sys
 from abc import ABC
+from typing import OrderedDict
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +31,31 @@ def create_s256_code_challenge(code_verifier):
     """Create S256 code_challenge with the given code_verifier."""
     data = hashlib.sha256(code_verifier.encode('ascii')).digest()
     return base64.urlsafe_b64encode(data).rstrip(b'=').decode('UTF-8')
+
+
+class RetrySession(requests.Session):
+    """A `requests.Session` with `Retry`."""
+
+    def __init__(
+        self,
+        retries=3,
+        backoff_factor=0.3,
+        status_forcelist=None,
+        allowed_methods=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        retry = Retry(
+            total=retries,
+            read=retries,
+            connect=retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist,
+            allowed_methods=allowed_methods,
+        )
+        self.adapters = OrderedDict()
+        self.mount('http://', HTTPAdapter(max_retries=retry))
+        self.mount('https://', HTTPAdapter(max_retries=retry))
 
 
 def serialize_for_json(obj: object, excluded: list = None, exclude_hidden: bool = True) -> dict:

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -1,13 +1,31 @@
 """General utils and base classes used in the library."""
 
-from abc import ABC
+import base64
 import datetime
+import hashlib
 import inspect
 import json
 import logging
+import random
+import string
 import sys
+from abc import ABC
 
 _LOGGER = logging.getLogger(__name__)
+
+UNICODE_CHARACTER_SET = string.ascii_letters + string.digits + '-._~'
+
+
+def generate_token(length=30, chars=UNICODE_CHARACTER_SET):
+    """Generate a random token with given length and characters."""
+    rand = random.SystemRandom()
+    return ''.join(rand.choice(chars) for _ in range(length))
+
+
+def create_s256_code_challenge(code_verifier):
+    """Create S256 code_challenge with the given code_verifier."""
+    data = hashlib.sha256(code_verifier.encode('ascii')).digest()
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('UTF-8')
 
 
 def serialize_for_json(obj: object, excluded: list = None, exclude_hidden: bool = True) -> dict:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR includes various changes to improve the flaky login/unauthorized situation:
* Add `-10s` offset when storing token expiry to mitigate timing issues on `/vehicles` endpoint
* Add retry strategy to `north_america`/`rest_of_world` login
  * Sometimes the `/authenticate` endpoint does not seem to work correctly, happend to me in the Android app as well

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #393
- This PR is related to issue: https://github.com/home-assistant/core/issues/63214

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
