### PR TITLE
Type `backend_parameter` decorator functions

### DIFF
--- a/bimmer_connected/charging_profile.py
+++ b/bimmer_connected/charging_profile.py
@@ -7,7 +7,15 @@ from enum import Enum
 from bimmer_connected.utils import SerializableBaseClass
 
 if TYPE_CHECKING:
+    from typing import Callable, TypeVar
+
+    from typing_extensions import Concatenate, ParamSpec
+
     from bimmer_connected.vehicle_status import VehicleStatus
+
+    _T = TypeVar("_T", bound="ChargingProfile")
+    _R = TypeVar("_R")
+    _P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,12 +100,14 @@ class DepartureTimer(SerializableBaseClass):
         return self._timer_dict.get("timerWeekDays")
 
 
-def backend_parameter(func):
+def backend_parameter(
+    func: "Callable[Concatenate[_T, _P], _R]"
+) -> "Callable[Concatenate[_T, _P], _R | None]":
     """Decorator for parameters reading data from the backend.
 
     Errors are handled in a default way.
     """
-    def _func_wrapper(self: 'ChargingProfile', *args, **kwargs):
+    def _func_wrapper(self: "_T", *args: "_P.args", **kwargs: "_P.kwargs") -> "_R | None":
         # pylint: disable=protected-access
         if self.charging_profile is None:
             raise ValueError('No data available for vehicles charging profile!')

--- a/bimmer_connected/charging_profile.py
+++ b/bimmer_connected/charging_profile.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     from bimmer_connected.vehicle_status import VehicleStatus
 
-    _T = TypeVar("_T", bound="ChargingProfile")
+    _ChargingProfileT = TypeVar("_ChargingProfileT", bound="ChargingProfile")
     _R = TypeVar("_R")
     _P = ParamSpec("_P")
 
@@ -101,13 +101,15 @@ class DepartureTimer(SerializableBaseClass):
 
 
 def backend_parameter(
-    func: "Callable[Concatenate[_T, _P], _R]"
-) -> "Callable[Concatenate[_T, _P], _R | None]":
+    func: "Callable[Concatenate[_ChargingProfileT, _P], _R]"
+) -> "Callable[Concatenate[_ChargingProfileT, _P], _R | None]":
     """Decorator for parameters reading data from the backend.
 
     Errors are handled in a default way.
     """
-    def _func_wrapper(self: "_T", *args: "_P.args", **kwargs: "_P.kwargs") -> "_R | None":
+    def _func_wrapper(
+        self: "_ChargingProfileT", *args: "_P.args", **kwargs: "_P.kwargs"
+    ) -> "_R | None":
         # pylint: disable=protected-access
         if self.charging_profile is None:
             raise ValueError('No data available for vehicles charging profile!')

--- a/bimmer_connected/vehicle_status.py
+++ b/bimmer_connected/vehicle_status.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Concatenate, ParamSpec
 
-    _T = TypeVar("_T", bound="VehicleStatus")
+    _VehicleStatusT = TypeVar("_VehicleStatusT", bound="VehicleStatus")
     _R = TypeVar("_R")
     _P = ParamSpec("_P")
 
@@ -182,13 +182,15 @@ class FuelIndicator(SerializableBaseClass):
 
 
 def backend_parameter(
-    func: "Callable[Concatenate[_T, _P], _R]"
-) -> "Callable[Concatenate[_T, _P], _R | None]":
+    func: "Callable[Concatenate[_VehicleStatusT, _P], _R]"
+) -> "Callable[Concatenate[_VehicleStatusT, _P], _R | None]":
     """Decorator for parameters reading data from the backend.
 
     Errors are handled in a default way.
     """
-    def _func_wrapper(self: "_T", *args: "_P.args", **kwargs: "_P.kwargs") -> "_R | None":
+    def _func_wrapper(
+        self: "_VehicleStatusT", *args: "_P.args", **kwargs: "_P.kwargs"
+    ) -> "_R | None":
         # pylint: disable=protected-access
         if self.properties is None and self.status is None:
             raise ValueError('No data available for vehicle status!')

--- a/bimmer_connected/vehicle_status.py
+++ b/bimmer_connected/vehicle_status.py
@@ -11,7 +11,15 @@ from bimmer_connected.country_selector import Regions
 from bimmer_connected.utils import SerializableBaseClass, parse_datetime
 
 if TYPE_CHECKING:
+    from typing import Callable, TypeVar
+
     from bimmer_connected.account import ConnectedDriveAccount
+
+    from typing_extensions import Concatenate, ParamSpec
+
+    _T = TypeVar("_T", bound="VehicleStatus")
+    _R = TypeVar("_R")
+    _P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,12 +181,14 @@ class FuelIndicator(SerializableBaseClass):
         return (range_val, fuel_indicator["rangeUnits"])
 
 
-def backend_parameter(func):
+def backend_parameter(
+    func: "Callable[Concatenate[_T, _P], _R]"
+) -> "Callable[Concatenate[_T, _P], _R | None]":
     """Decorator for parameters reading data from the backend.
 
     Errors are handled in a default way.
     """
-    def _func_wrapper(self: 'VehicleStatus', *args, **kwargs):
+    def _func_wrapper(self: "_T", *args: "_P.args", **kwargs: "_P.kwargs") -> "_R | None":
         # pylint: disable=protected-access
         if self.properties is None and self.status is None:
             raise ValueError('No data available for vehicle status!')

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ requests-mock
 flake8
 pbr
 time_machine
+typing_extensions>=3.10.0.2,<5.0


### PR DESCRIPTION
## Proposed change
During my initial typing changes I noticed the custom decorator functions `backend_paramter`. At the time I was unsure how to best type it. A few weeks ago, a new mypy version was released with experimental support for [PEP 612 - ParamSpec](https://www.python.org/dev/peps/pep-0612/). Together with `Concatenate`, `ParamSpec` was explicitly designed so decorators like this one can be properly typed.

Mypy doesn't yet understand `Concatenate`. That doesn't matter though as the function was already inferred as `Any` and that doesn't change. `Pylance` however can interpret it. To see the impact of this change, I would suggest to open
[HomeAssistant -> bmw_conntected_drive/binary_sensor.py](https://github.com/home-assistant/core/blob/d2c06c59471bc918f007d4ba604c91284833446e/homeassistant/components/bmw_connected_drive/binary_sensor.py) in VS Code. Note that the types of the `vehicle_state.xxx` properties have change now to indicate that they can also be `None`.

`ParamSpec` itself is a Python 3.10 feature. It can however be used in earlier versions if imported from `typing_extensions` and used in string annotations. Although possible, I put the import inside the `if TYPE_CHECKING` block. That way `typing-extensions` doesn't need to be added as a runtime dependency.

Lastly, I replaced the `self` types with bound TypeVars. That allows for more future compatibility. E.g. if the decorator should be used in a subclass. That wouldn't be possible with a hardcoded type for `self`.


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
