### PR TITLE
Fix typing & defaults for attributes with units

### DIFF
--- a/bimmer_connected/vehicle_status.py
+++ b/bimmer_connected/vehicle_status.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 from enum import Enum
-from typing import Dict, List, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from bimmer_connected.coord_convert import gcj2wgs
 
@@ -95,10 +95,10 @@ class FuelIndicator(SerializableBaseClass):
     # pylint: disable=too-few-public-methods, too-many-instance-attributes
 
     def __init__(self, fuel_indicator_dict: List):
-        self.remaining_range_fuel: int = None
-        self.remaining_range_electric: int = None
-        self.remaining_range_combined: int = None
-        self.remaining_charging_time: int = None
+        self.remaining_range_fuel: Optional[Tuple[int, str]] = None
+        self.remaining_range_electric: Optional[Tuple[int, str]] = None
+        self.remaining_range_combined: Optional[Tuple[int, str]] = None
+        self.remaining_charging_time: float = None
         self.charging_status: str = None
         self.charging_start_time: datetime.datetime = None
         self.charging_end_time: datetime.datetime = None
@@ -241,10 +241,10 @@ class VehicleStatus(SerializableBaseClass):  # pylint: disable=too-many-public-m
         """
         if self.is_vehicle_active:
             _LOGGER.info('Vehicle was moving at last update, no position available')
-            return None
+            return (None, None)
         if not self._remote_service_position and "vehicleLocation" not in self.properties:
             _LOGGER.info("No vehicle location data available.")
-            return None
+            return (None, None)
 
         t_remote = self._remote_service_position.get(
             "timestamp",
@@ -298,7 +298,7 @@ class VehicleStatus(SerializableBaseClass):  # pylint: disable=too-many-public-m
 
     @property
     @backend_parameter
-    def mileage(self) -> int:
+    def mileage(self) -> Tuple[int, str]:
         """Get the mileage of the vehicle.
 
         Returns a tuple of (value, unit_of_measurement)
@@ -315,11 +315,11 @@ class VehicleStatus(SerializableBaseClass):  # pylint: disable=too-many-public-m
 
         Returns a tuple of (value, unit_of_measurement)
         """
-        return self._fuel_indicators.remaining_range_fuel
+        return self._fuel_indicators.remaining_range_fuel or (None, None)
 
     @property
     @backend_parameter
-    def remaining_fuel(self) -> int:
+    def remaining_fuel(self) -> Tuple[int, str]:
         """Get the remaining fuel of the vehicle.
 
         Returns a tuple of (value, unit_of_measurement)
@@ -452,16 +452,16 @@ class VehicleStatus(SerializableBaseClass):  # pylint: disable=too-many-public-m
     @backend_parameter
     def remaining_range_electric(self) -> Tuple[int, str]:
         """Remaining range on battery, in kilometers."""
-        return self._fuel_indicators.remaining_range_electric
+        return self._fuel_indicators.remaining_range_electric or (None, None)
 
     @property
     @backend_parameter
-    def remaining_range_total(self) -> int:
+    def remaining_range_total(self) -> Tuple[int, str]:
         """Get the total remaining range of the vehicle in kilometers.
 
         That is electrical range + fuel range.
         """
-        return self._fuel_indicators.remaining_range_combined
+        return self._fuel_indicators.remaining_range_combined or (None, None)
 
     @property
     @backend_parameter

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -44,13 +44,13 @@ class TestState(unittest.TestCase):
         status = get_mocked_account().get_vehicle(VIN_F31).status
 
         self.assertTupleEqual((32, "LITERS"), status.remaining_fuel)
-        self.assertIsNone(status.remaining_range_fuel)
+        self.assertTupleEqual((None, None), status.remaining_range_fuel)
         self.assertIsNone(status.fuel_percent)
 
         self.assertIsNone(status.charging_level_hv)
-        self.assertIsNone(status.remaining_range_electric)
+        self.assertTupleEqual((None, None), status.remaining_range_electric)
 
-        self.assertIsNone(status.remaining_range_total)
+        self.assertTupleEqual((None, None), status.remaining_range_total)
 
     def test_range_combustion(self):
         """Test if the parsing of mileage and range is working"""
@@ -61,7 +61,7 @@ class TestState(unittest.TestCase):
         self.assertIsNone(status.fuel_percent)
 
         self.assertIsNone(status.charging_level_hv)
-        self.assertIsNone(status.remaining_range_electric)
+        self.assertTupleEqual((None, None), status.remaining_range_electric)
 
         self.assertTupleEqual((308, "km"), status.remaining_range_total)
 
@@ -104,7 +104,7 @@ class TestState(unittest.TestCase):
         status = get_mocked_account().get_vehicle(VIN_G08).status
 
         self.assertTupleEqual((0, "LITERS"), status.remaining_fuel)
-        self.assertIsNone(status.remaining_range_fuel)
+        self.assertTupleEqual((None, None), status.remaining_range_fuel)
         self.assertEqual(0, status.fuel_percent)
 
         self.assertAlmostEqual(50, status.charging_level_hv)
@@ -203,7 +203,7 @@ class TestState(unittest.TestCase):
         """Test parsing of F31 data with position tracking disabled in the vehicle."""
         status = get_mocked_account().get_vehicle(VIN_F31).status
 
-        self.assertIsNone(status.gps_position)
+        self.assertTupleEqual((None, None), status.gps_position)
         self.assertIsNone(status.gps_heading)
 
     def test_parse_gcj02_position(self):
@@ -238,7 +238,7 @@ class TestState(unittest.TestCase):
         self.assertTrue(vehicle.is_vehicle_tracking_enabled)
         self.assertTrue(status.is_vehicle_active)
         with self.assertLogs(level=logging.INFO):
-            self.assertIsNone(status.gps_position)
+            self.assertTupleEqual((None, None), status.gps_position)
             self.assertIsNone(status.gps_heading)
 
     def test_parse_g08(self):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates typing & NoneType handling for attributes with units (should be `Tuple`, but could be `None` if no data is availabe).
Should fix `TypeError: 'NoneType' object is not subscriptable` in the HA component.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #399 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
