### PR TITLE
Don't store GCJ02 converted position to VehicleStatus

### DIFF
--- a/bimmer_connected/vehicle_status.py
+++ b/bimmer_connected/vehicle_status.py
@@ -257,6 +257,7 @@ class VehicleStatus(SerializableBaseClass):  # pylint: disable=too-many-public-m
 
         # Convert GCJ02 to WGS84 for positions in China
         if self._account.region == Regions.CHINA:
+            pos = pos.copy()
             pos['longitude'], pos['latitude'] = gcj2wgs(gcjLon=pos['longitude'], gcjLat=pos['latitude'])
 
         return float(pos['latitude']), float(pos['longitude'])

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -227,7 +227,7 @@ class TestState(unittest.TestCase):
             },
         )
         self.assertTupleEqual(
-            (39.8337, 116.22012), (round(status.gps_position[0], 5), round(status.gps_position[1], 5))
+            (39.8337, 116.22617), (round(status.gps_position[0], 5), round(status.gps_position[1], 5))
         )
 
     def test_parse_f11_no_position_vehicle_active(self):


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For vehicles in `CHINA`, the vehicle location was slowly moving as the converstion from GCJ02 to WGS84 actually stored the converted data back to the originally referenced dictionary in `VehicleStatus`. 

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #419 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
