### PR TITLE
Refactor auth flow

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -1,6 +1,5 @@
 """Access to a MyBMW account and all vehicles therein."""
 
-import asyncio
 import datetime
 import logging
 import pathlib
@@ -64,18 +63,14 @@ class MyBMWAccount:  # pylint: disable=too-many-instance-attributes
                 "appDateTime": int(datetime.datetime.now().timestamp() * 1000),
                 "tireGuardMode": "ENABLED",
             }
-            vehicles_tasks: List[asyncio.Task] = []
-            for brand in CarBrands:
-                vehicles_tasks.append(
-                    asyncio.ensure_future(
-                        client.get(
-                            VEHICLES_URL,
-                            params=vehicles_request_params,
-                            headers=client.generate_default_header(brand),
-                        )
-                    )
+            vehicles_responses: List[httpx.Response] = [
+                await client.get(
+                    VEHICLES_URL,
+                    params=vehicles_request_params,
+                    headers=client.generate_default_header(brand),
                 )
-            vehicles_responses: List[httpx.Response] = await asyncio.gather(*vehicles_tasks)
+                for brand in CarBrands
+            ]
 
             for response in vehicles_responses:
                 for vehicle_dict in response.json():

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -19,7 +19,6 @@ from bimmer_connected.vehicle.models import GPSPosition
 VALID_UNTIL_OFFSET = datetime.timedelta(seconds=10)
 
 _LOGGER = logging.getLogger(__name__)
-# lock = asyncio.Lock()
 
 
 @dataclass

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -74,7 +74,7 @@ class MyBMWAuthentication(httpx.Auth):
         async with self.login_lock:
             if not self.access_token:
                 await self.login()
-        request.headers["authorization"] = f"Bearer {self.access_token}"
+        request.headers["authorization"] = f"Bearer {self.access_token or ''}"
         request.headers["bmw-session-id"] = self.session_id
 
         # Try getting a response
@@ -84,7 +84,7 @@ class MyBMWAuthentication(httpx.Auth):
             async with self.login_lock:
                 _LOGGER.debug("Received unauthorized response, refreshing token.")
                 await self.login()
-            request.headers["authorization"] = f"Bearer {self.access_token}"
+            request.headers["authorization"] = f"Bearer {self.access_token or ''}"
             request.headers["bmw-session-id"] = self.session_id
             yield request
 
@@ -203,7 +203,7 @@ class MyBMWAuthentication(httpx.Auth):
         """Login to Rest of World and North America using existing refresh_token."""
         try:
             async with MyBMWLoginClient(region=self.region) as client:
-                _LOGGER.debug("Authenticating with refresh_token flow for North America & Rest of World.")
+                _LOGGER.debug("Authenticating with refresh token for North America & Rest of World.")
 
                 # Get OAuth2 settings from BMW API
                 r_oauth_settings = await client.get(

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -1,11 +1,10 @@
 """Authentication management for BMW APIs."""
 
-import asyncio
 import base64
 import datetime
 import logging
-from dataclasses import dataclass, field
-from typing import Optional
+from collections import defaultdict
+from typing import AsyncGenerator, Generator, Optional
 
 import httpx
 import jwt
@@ -14,12 +13,7 @@ from Crypto.PublicKey import RSA
 from Crypto.Util.Padding import pad
 
 from bimmer_connected.api.regions import Regions, get_aes_keys, get_ocp_apim_key, get_server_url
-from bimmer_connected.api.utils import (
-    create_s256_code_challenge,
-    generate_token,
-    handle_http_status_error,
-    raise_for_status_event_handler,
-)
+from bimmer_connected.api.utils import create_s256_code_challenge, generate_token, handle_http_status_error
 from bimmer_connected.const import (
     AUTH_CHINA_LOGIN_URL,
     AUTH_CHINA_PUBLIC_KEY_URL,
@@ -30,58 +24,50 @@ from bimmer_connected.const import (
     X_USER_AGENT,
 )
 
+EXPIRES_AT_OFFSET = datetime.timedelta(seconds=30)
+
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
-class Authentication:
-    """Base class for Authentication."""
-
-    username: str
-    password: str
-    region: Regions
-    token: Optional[str] = None
-    expires_at: Optional[datetime.datetime] = None
-    refresh_token: Optional[str] = None
-
-    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-
-    def _create_or_update_lock(self):
-        """Makes sure that there is a lock in the current event loop."""
-        loop: asyncio.BaseEventLoop = self._lock._loop  # pylint: disable=protected-access
-        if loop != asyncio.get_event_loop():
-            self._lock = asyncio.Lock()
-
-    async def login(self) -> None:
-        """Get a valid OAuth token."""
-        raise NotImplementedError("Not implemented in Authentication base class.")
-
-    async def get_authentication(self) -> str:
-        """Returns a valid Bearer token."""
-        self._create_or_update_lock()
-        async with self._lock:
-            if not self.is_token_valid:
-                await self.login()
-        return f"Bearer {self.token}"
-
-    @property
-    def is_token_valid(self) -> bool:
-        """Check if current token is still valid."""
-        if self.token and self.expires_at and datetime.datetime.utcnow() < self.expires_at:
-            _LOGGER.debug("Old token is still valid. Not getting a new one.")
-            return True
-        return False
-
-
-@dataclass
-class MyBMWAuthentication(Authentication):
+class MyBMWAuthentication(httpx.Auth):
     """Authentication for MyBMW API."""
 
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        region: Regions,
+        access_token: Optional[str] = None,
+        expires_at: Optional[datetime.datetime] = None,
+        refresh_token: Optional[str] = None,
+    ):
+        self.username = username
+        self.password = password
+        self.region = region
+        self.access_token = access_token
+        self.expires_at = expires_at
+        self.refresh_token = refresh_token
+
+    def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        raise RuntimeError("Cannot use a async authentication class with httpx.Client")
+
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        # Get an access token on first call
+        if not self.access_token or (self.expires_at and self.expires_at < datetime.datetime.utcnow()):
+            await self.login()
+        request.headers["authorization"] = f"Bearer {self.access_token}"
+
+        # Try getting a response
+        response: httpx.Response = yield request
+
+        if response.status_code == 401:
+            await self.login()
+            request.headers["authorization"] = f"Bearer {self.access_token}"
+            yield request
+
     async def login(self) -> None:
         """Get a valid OAuth token."""
-        if self.is_token_valid:
-            return
-
         token_data = {}
         if self.region in [Regions.NORTH_AMERICA, Regions.REST_OF_WORLD]:
             # Try logging in with refresh token first
@@ -89,7 +75,7 @@ class MyBMWAuthentication(Authentication):
                 token_data = await self._refresh_token_row_na()
             if not token_data:
                 token_data = await self._login_row_na()
-            token_data["expires_at"] = token_data["expires_at"] - datetime.timedelta(seconds=10)
+            token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 
         elif self.region in [Regions.CHINA]:
             # Try logging in with refresh token first
@@ -97,31 +83,23 @@ class MyBMWAuthentication(Authentication):
                 token_data = await self._refresh_token_china()
             if not token_data:
                 token_data = await self._login_china()
-            token_data["expires_at"] = token_data["expires_at"] - datetime.timedelta(seconds=300)
+            token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 
-        self.token = token_data["access_token"]
+        self.access_token = token_data["access_token"]
         self.expires_at = token_data["expires_at"]
         self.refresh_token = token_data["refresh_token"]
 
     async def _login_row_na(self):  # pylint: disable=too-many-locals
         """Login to Rest of World and North America."""
         try:
-            async with httpx.AsyncClient(
-                base_url=get_server_url(self.region),
-                headers={"user-agent": USER_AGENT},
-                timeout=httpx.Timeout(HTTPX_TIMEOUT),
-            ) as client:
+            async with MyBMWLoginClient(region=self.region) as client:
                 _LOGGER.debug("Authenticating with MyBMW flow for North America & Rest of World.")
-
-                # Attach raise_for_status event hook
-                client.event_hooks["response"].append(raise_for_status_event_handler)
 
                 # Get OAuth2 settings from BMW API
                 r_oauth_settings = await client.get(
                     OAUTH_CONFIG_URL,
                     headers={
                         "ocp-apim-subscription-key": get_ocp_apim_key(self.region),
-                        "x-user-agent": X_USER_AGENT.format("bmw"),
                     },
                 )
                 oauth_settings = r_oauth_settings.json()
@@ -195,22 +173,14 @@ class MyBMWAuthentication(Authentication):
     async def _refresh_token_row_na(self):
         """Login to Rest of World and North America using existing refresh_token."""
         try:
-            async with httpx.AsyncClient(
-                base_url=get_server_url(self.region),
-                headers={"user-agent": USER_AGENT},
-                timeout=httpx.Timeout(HTTPX_TIMEOUT),
-            ) as client:
+            async with MyBMWLoginClient(region=self.region) as client:
                 _LOGGER.debug("Authenticating with refresh_token flow for North America & Rest of World.")
-
-                # Attach raise_for_status event hook
-                client.event_hooks["response"].append(raise_for_status_event_handler)
 
                 # Get OAuth2 settings from BMW API
                 r_oauth_settings = await client.get(
                     OAUTH_CONFIG_URL,
                     headers={
                         "ocp-apim-subscription-key": get_ocp_apim_key(self.region),
-                        "x-user-agent": X_USER_AGENT.format("bmw"),
                     },
                 )
                 oauth_settings = r_oauth_settings.json()
@@ -244,22 +214,12 @@ class MyBMWAuthentication(Authentication):
 
     async def _login_china(self):
         try:
-            async with httpx.AsyncClient(
-                base_url=get_server_url(self.region),
-                headers={"user-agent": USER_AGENT},
-                timeout=httpx.Timeout(HTTPX_TIMEOUT),
-            ) as client:
+            async with MyBMWLoginClient(region=self.region) as client:
                 _LOGGER.debug("Authenticating with MyBMW flow for China.")
-
-                # Attach raise_for_status event hook
-                client.event_hooks["response"].append(raise_for_status_event_handler)
-
-                login_header = {"x-user-agent": X_USER_AGENT.format("bmw")}
 
                 # Get current RSA public certificate & use it to encrypt password
                 response = await client.get(
                     AUTH_CHINA_PUBLIC_KEY_URL,
-                    headers=login_header,
                 )
                 pem_public_key = response.json()["data"]["value"]
 
@@ -271,11 +231,11 @@ class MyBMWAuthentication(Authentication):
                 cipher_aes = AES.new(**get_aes_keys(self.region), mode=AES.MODE_CBC)
                 nonce = f"{self.username}|{datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%fZ')}".encode()
 
-                login_header["x-login-nonce"] = base64.b64encode(cipher_aes.encrypt(pad(nonce, 16))).decode()
-
                 # Get token
                 response = await client.post(
-                    AUTH_CHINA_LOGIN_URL, headers=login_header, json={"mobile": self.username, "password": pw_encrypted}
+                    AUTH_CHINA_LOGIN_URL,
+                    headers={"x-login-nonce": base64.b64encode(cipher_aes.encrypt(pad(nonce, 16))).decode()},
+                    json={"mobile": self.username, "password": pw_encrypted},
                 )
                 response_json = response.json()["data"]
 
@@ -288,29 +248,20 @@ class MyBMWAuthentication(Authentication):
 
         return {
             "access_token": response_json["access_token"],
-            "expires_at": datetime.datetime.utcfromtimestamp(decoded_token["exp"]),
+            "expires_at": datetime.datetime.utcfromtimestamp(decoded_token["exp"]) - datetime.timedelta(minutes=55),
             "refresh_token": response_json["refresh_token"],
         }
 
     async def _refresh_token_china(self):
         try:
-            async with httpx.AsyncClient(
-                base_url=get_server_url(self.region),
-                headers={"user-agent": USER_AGENT},
-                timeout=httpx.Timeout(HTTPX_TIMEOUT),
-            ) as client:
+            async with MyBMWLoginClient(region=self.region) as client:
                 _LOGGER.debug("Authenticating with refresh token for China.")
 
-                # Attach raise_for_status event hook
-                client.event_hooks["response"].append(raise_for_status_event_handler)
-
-                login_header = {"x-user-agent": X_USER_AGENT.format("bmw")}
                 current_utc_time = datetime.datetime.utcnow()
 
                 # Try logging in using refresh_token
                 response = await client.post(
                     AUTH_CHINA_TOKEN_URL,
-                    headers=login_header,
                     data={
                         "refresh_token": self.refresh_token,
                         "grant_type": "refresh_token",
@@ -319,7 +270,9 @@ class MyBMWAuthentication(Authentication):
                 response_json = response.json()
 
                 expiration_time = int(response_json["expires_in"])
-                expires_at = current_utc_time + datetime.timedelta(seconds=expiration_time)
+                expires_at = (
+                    current_utc_time + datetime.timedelta(seconds=expiration_time) - datetime.timedelta(minutes=55)
+                )
 
         except httpx.HTTPStatusError:
             _LOGGER.debug("Unable to get access token using refresh token.")
@@ -330,3 +283,32 @@ class MyBMWAuthentication(Authentication):
             "expires_at": expires_at,
             "refresh_token": response_json["refresh_token"],
         }
+
+
+class MyBMWLoginClient(httpx.AsyncClient):
+    """Async HTTP client based on `httpx.AsyncClient` with automated OAuth token refresh."""
+
+    def __init__(self, *args, **kwargs):
+        # Increase timeout
+        kwargs["timeout"] = httpx.Timeout(HTTPX_TIMEOUT)
+
+        # Set default values
+        kwargs["base_url"] = get_server_url(kwargs.pop("region"))
+        kwargs["headers"] = {"user-agent": USER_AGENT, "x-user-agent": X_USER_AGENT.format("bmw")}
+
+        # Register event hooks
+        kwargs["event_hooks"] = defaultdict(list, **kwargs.get("event_hooks", {}))
+
+        # Event hook which calls raise_for_status on all requests
+        async def raise_for_status_event_handler(response: httpx.Response):
+            """Event handler that automatically raises HTTPStatusErrors when attached.
+
+            Will only raise on 4xx/5xx errors (incl. 401) and not raise on 3xx.
+            """
+            if response.is_error:
+                await response.aread()
+                response.raise_for_status()
+
+        kwargs["event_hooks"]["response"].append(raise_for_status_event_handler)
+
+        super().__init__(*args, **kwargs)

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -15,7 +15,12 @@ from Crypto.PublicKey import RSA
 from Crypto.Util.Padding import pad
 
 from bimmer_connected.api.regions import Regions, get_aes_keys, get_ocp_apim_key, get_server_url
-from bimmer_connected.api.utils import create_s256_code_challenge, generate_token, handle_http_status_error
+from bimmer_connected.api.utils import (
+    create_s256_code_challenge,
+    generate_token,
+    get_correlation_id,
+    handle_http_status_error,
+)
 from bimmer_connected.const import (
     AUTH_CHINA_LOGIN_URL,
     AUTH_CHINA_PUBLIC_KEY_URL,
@@ -50,7 +55,7 @@ class MyBMWAuthentication(httpx.Auth):
         self.access_token: Optional[str] = access_token
         self.expires_at: Optional[datetime.datetime] = expires_at
         self.refresh_token: Optional[str] = refresh_token
-        self.session_id: Optional[str] = None
+        self.session_id: Optional[str] = str(uuid4())
         self._lock: Optional[asyncio.Lock] = None
 
     @property
@@ -121,6 +126,8 @@ class MyBMWAuthentication(httpx.Auth):
                     OAUTH_CONFIG_URL,
                     headers={
                         "ocp-apim-subscription-key": get_ocp_apim_key(self.region),
+                        "bmw-session-id": self.session_id,
+                        **get_correlation_id(),
                     },
                 )
                 oauth_settings = r_oauth_settings.json()
@@ -202,6 +209,8 @@ class MyBMWAuthentication(httpx.Auth):
                     OAUTH_CONFIG_URL,
                     headers={
                         "ocp-apim-subscription-key": get_ocp_apim_key(self.region),
+                        "bmw-session-id": self.session_id,
+                        **get_correlation_id(),
                     },
                 )
                 oauth_settings = r_oauth_settings.json()

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -232,8 +232,9 @@ class MyBMWAuthentication(httpx.Auth):
                 expiration_time = int(response_json["expires_in"])
                 expires_at = current_utc_time + datetime.timedelta(seconds=expiration_time)
 
-        except httpx.HTTPStatusError:
+        except httpx.HTTPStatusError as ex:
             _LOGGER.debug("Unable to get access token using refresh token.")
+            handle_http_status_error(ex, "Authentication", _LOGGER, debug=True)
             return {}
 
         return {
@@ -302,8 +303,9 @@ class MyBMWAuthentication(httpx.Auth):
                 expiration_time = int(response_json["expires_in"])
                 expires_at = current_utc_time + datetime.timedelta(seconds=expiration_time)
 
-        except httpx.HTTPStatusError:
+        except httpx.HTTPStatusError as ex:
             _LOGGER.debug("Unable to get access token using refresh token.")
+            handle_http_status_error(ex, "Authentication", _LOGGER, debug=True)
             return {}
 
         return {

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -99,6 +99,8 @@ class MyBMWAuthentication(httpx.Auth):
             if self.refresh_token:
                 token_data = await self._refresh_token_row_na()
             if not token_data:
+                # clear refresh token as precaution
+                self.refresh_token = None
                 token_data = await self._login_row_na()
             token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 
@@ -107,6 +109,8 @@ class MyBMWAuthentication(httpx.Auth):
             if self.refresh_token:
                 token_data = await self._refresh_token_china()
             if not token_data:
+                # clear refresh token as precaution
+                self.refresh_token = None
                 token_data = await self._login_china()
             token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
 

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -56,7 +56,7 @@ class MyBMWAuthentication(httpx.Auth):
         self.access_token: Optional[str] = access_token
         self.expires_at: Optional[datetime.datetime] = expires_at
         self.refresh_token: Optional[str] = refresh_token
-        self.session_id: Optional[str] = str(uuid4())
+        self.session_id: str = str(uuid4())
         self._lock: Optional[asyncio.Lock] = None
 
     @property
@@ -74,7 +74,7 @@ class MyBMWAuthentication(httpx.Auth):
         async with self.login_lock:
             if not self.access_token:
                 await self.login()
-        request.headers["authorization"] = f"Bearer {self.access_token or ''}"
+        request.headers["authorization"] = f"Bearer {self.access_token}"
         request.headers["bmw-session-id"] = self.session_id
 
         # Try getting a response
@@ -84,7 +84,7 @@ class MyBMWAuthentication(httpx.Auth):
             async with self.login_lock:
                 _LOGGER.debug("Received unauthorized response, refreshing token.")
                 await self.login()
-            request.headers["authorization"] = f"Bearer {self.access_token or ''}"
+            request.headers["authorization"] = f"Bearer {self.access_token}"
             request.headers["bmw-session-id"] = self.session_id
             yield request
 
@@ -114,7 +114,6 @@ class MyBMWAuthentication(httpx.Auth):
         self.access_token = token_data["access_token"]
         self.expires_at = token_data["expires_at"]
         self.refresh_token = token_data["refresh_token"]
-        self.session_id = str(uuid4())
 
     async def _login_row_na(self):  # pylint: disable=too-many-locals
         """Login to Rest of World and North America."""

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -24,6 +24,7 @@ from bimmer_connected.const import (
     AUTH_CHINA_LOGIN_URL,
     AUTH_CHINA_PUBLIC_KEY_URL,
     AUTH_CHINA_TOKEN_URL,
+    HTTPX_TIMEOUT,
     OAUTH_CONFIG_URL,
     USER_AGENT,
     X_USER_AGENT,
@@ -106,7 +107,9 @@ class MyBMWAuthentication(Authentication):
         """Login to Rest of World and North America."""
         try:
             async with httpx.AsyncClient(
-                base_url=get_server_url(self.region), headers={"user-agent": USER_AGENT}
+                base_url=get_server_url(self.region),
+                headers={"user-agent": USER_AGENT},
+                timeout=httpx.Timeout(HTTPX_TIMEOUT),
             ) as client:
                 _LOGGER.debug("Authenticating with MyBMW flow for North America & Rest of World.")
 
@@ -193,7 +196,9 @@ class MyBMWAuthentication(Authentication):
         """Login to Rest of World and North America using existing refresh_token."""
         try:
             async with httpx.AsyncClient(
-                base_url=get_server_url(self.region), headers={"user-agent": USER_AGENT}
+                base_url=get_server_url(self.region),
+                headers={"user-agent": USER_AGENT},
+                timeout=httpx.Timeout(HTTPX_TIMEOUT),
             ) as client:
                 _LOGGER.debug("Authenticating with refresh_token flow for North America & Rest of World.")
 
@@ -240,7 +245,9 @@ class MyBMWAuthentication(Authentication):
     async def _login_china(self):
         try:
             async with httpx.AsyncClient(
-                base_url=get_server_url(self.region), headers={"user-agent": USER_AGENT}
+                base_url=get_server_url(self.region),
+                headers={"user-agent": USER_AGENT},
+                timeout=httpx.Timeout(HTTPX_TIMEOUT),
             ) as client:
                 _LOGGER.debug("Authenticating with MyBMW flow for China.")
 
@@ -288,7 +295,9 @@ class MyBMWAuthentication(Authentication):
     async def _refresh_token_china(self):
         try:
             async with httpx.AsyncClient(
-                base_url=get_server_url(self.region), headers={"user-agent": USER_AGENT}
+                base_url=get_server_url(self.region),
+                headers={"user-agent": USER_AGENT},
+                timeout=httpx.Timeout(HTTPX_TIMEOUT),
             ) as client:
                 _LOGGER.debug("Authenticating with refresh token for China.")
 

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -30,8 +30,6 @@ from bimmer_connected.const import (
     X_USER_AGENT,
 )
 
-EXPIRES_AT_OFFSET = datetime.timedelta(seconds=10)
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -91,6 +89,7 @@ class MyBMWAuthentication(Authentication):
                 token_data = await self._refresh_token_row_na()
             if not token_data:
                 token_data = await self._login_row_na()
+            token_data["expires_at"] = token_data["expires_at"] - datetime.timedelta(seconds=10)
 
         elif self.region in [Regions.CHINA]:
             # Try logging in with refresh token first
@@ -98,9 +97,10 @@ class MyBMWAuthentication(Authentication):
                 token_data = await self._refresh_token_china()
             if not token_data:
                 token_data = await self._login_china()
+            token_data["expires_at"] = token_data["expires_at"] - datetime.timedelta(seconds=300)
 
         self.token = token_data["access_token"]
-        self.expires_at = token_data["expires_at"] - EXPIRES_AT_OFFSET
+        self.expires_at = token_data["expires_at"]
         self.refresh_token = token_data["refresh_token"]
 
     async def _login_row_na(self):  # pylint: disable=too-many-locals

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -10,7 +10,7 @@ import httpx
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.api.regions import get_server_url
 from bimmer_connected.api.utils import log_to_to_file, raise_for_status_event_handler
-from bimmer_connected.const import USER_AGENT, X_USER_AGENT, CarBrands
+from bimmer_connected.const import HTTPX_TIMEOUT, USER_AGENT, X_USER_AGENT, CarBrands
 
 
 @dataclass
@@ -28,7 +28,7 @@ class MyBMWClient(httpx.AsyncClient):
         self.config = config
 
         # Increase timeout
-        kwargs["timeout"] = httpx.Timeout(10.0)
+        kwargs["timeout"] = httpx.Timeout(HTTPX_TIMEOUT)
 
         # Set default values
         kwargs["base_url"] = kwargs.get("base_url") or get_server_url(config.authentication.region)

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -4,13 +4,12 @@ import pathlib
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Optional
-from uuid import uuid4
 
 import httpx
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.api.regions import get_server_url
-from bimmer_connected.api.utils import log_to_to_file
+from bimmer_connected.api.utils import get_correlation_id, log_to_to_file
 from bimmer_connected.const import HTTPX_TIMEOUT, USER_AGENT, X_USER_AGENT, CarBrands
 
 
@@ -68,13 +67,10 @@ class MyBMWClient(httpx.AsyncClient):
     @staticmethod
     def generate_default_header(brand: CarBrands = None) -> Dict[str, str]:
         """Generate a header for HTTP requests to the server."""
-        correlation_id = str(uuid4())
         return {
             "accept": "application/json",
             "accept-language": "en",
             "user-agent": USER_AGENT,
             "x-user-agent": X_USER_AGENT.format(brand or CarBrands.BMW),
-            "x-identity-provider": "gcdm",
-            "x-correlation-id": correlation_id,
-            "bmw-correlation-id": correlation_id,
+            **get_correlation_id(),
         }

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -4,6 +4,7 @@ import pathlib
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Optional
+from uuid import uuid4
 
 import httpx
 
@@ -67,9 +68,13 @@ class MyBMWClient(httpx.AsyncClient):
     @staticmethod
     def generate_default_header(brand: CarBrands = None) -> Dict[str, str]:
         """Generate a header for HTTP requests to the server."""
+        correlation_id = str(uuid4())
         return {
             "accept": "application/json",
             "accept-language": "en",
             "user-agent": USER_AGENT,
             "x-user-agent": X_USER_AGENT.format(brand or CarBrands.BMW),
+            "x-identity-provider": "gcdm",
+            "x-correlation-id": correlation_id,
+            "bmw-correlation-id": correlation_id,
         }

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -9,7 +9,7 @@ import httpx
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.api.regions import get_server_url
-from bimmer_connected.api.utils import log_to_to_file, raise_for_status_event_handler
+from bimmer_connected.api.utils import log_to_to_file
 from bimmer_connected.const import HTTPX_TIMEOUT, USER_AGENT, X_USER_AGENT, CarBrands
 
 
@@ -27,6 +27,9 @@ class MyBMWClient(httpx.AsyncClient):
     def __init__(self, config: MyBMWClientConfiguration, *args, brand: CarBrands = None, **kwargs):
         self.config = config
 
+        # Add authentication
+        kwargs["auth"] = self.config.authentication
+
         # Increase timeout
         kwargs["timeout"] = httpx.Timeout(HTTPX_TIMEOUT)
 
@@ -36,12 +39,6 @@ class MyBMWClient(httpx.AsyncClient):
 
         # Register event hooks
         kwargs["event_hooks"] = defaultdict(list, **kwargs.get("event_hooks", {}))
-
-        # Event hook which checks and updates token if required before request is sent
-        async def update_request_header(request: httpx.Request):
-            request.headers["authorization"] = await self.config.authentication.get_authentication()
-
-        kwargs["event_hooks"]["request"].append(update_request_header)
 
         # Event hook for logging content to file
         async def log_response(response: httpx.Response):
@@ -54,6 +51,15 @@ class MyBMWClient(httpx.AsyncClient):
             kwargs["event_hooks"]["response"].append(log_response)
 
         # Event hook which calls raise_for_status on all requests
+        async def raise_for_status_event_handler(response: httpx.Response):
+            """Event handler that automatically raises HTTPStatusErrors when attached.
+
+            Will only raise on 4xx/5xx errors (but not 401!) and not raise on 3xx.
+            """
+            if response.is_error and response.status_code != 401:
+                await response.aread()
+                response.raise_for_status()
+
         kwargs["event_hooks"]["response"].append(raise_for_status_event_handler)
 
         super().__init__(*args, **kwargs)

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -38,16 +38,18 @@ def get_correlation_id() -> Dict[str, str]:
 
 
 def handle_http_status_error(
-    ex: httpx.HTTPStatusError, module: str = "MyBMW API", log_handler: logging.Logger = None
+    ex: httpx.HTTPStatusError, module: str = "MyBMW API", log_handler: logging.Logger = None, debug: bool = False
 ) -> None:
     """Try to extract information from response and re-raise Exception."""
     _logger = log_handler or logging.getLogger(__name__)
+    _level = logging.DEBUG if debug else logging.ERROR
     try:
         err = ex.response.json()
-        _logger.error("%s error (%s): %s", module, err["error"], err["error_description"])
+        _logger.log(_level, "%s error (%s): %s", module, err["error"], err["error_description"])
     except (json.JSONDecodeError, KeyError):
-        _logger.error("%s error: %s", module, ex.response.text)
-    raise ex
+        _logger.log(_level, "%s error: %s", module, ex.response.text)
+    if not debug:
+        raise ex
 
 
 def anonymize_data(json_data: Union[List, Dict]) -> Union[List, Dict]:

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -26,16 +26,6 @@ def create_s256_code_challenge(code_verifier: str) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("UTF-8")
 
 
-async def raise_for_status_event_handler(response: httpx.Response):
-    """Event handler that automatically raises HTTPStatusErrors when attached.
-
-    Will only raise on 4xx/5xx errors and not raise on 3xx.
-    """
-    if response.is_error:
-        await response.aread()
-        response.raise_for_status()
-
-
 def handle_http_status_error(
     ex: httpx.HTTPStatusError, module: str = "MyBMW API", log_handler: logging.Logger = None
 ) -> None:

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -8,6 +8,7 @@ import pathlib
 import random
 import string
 from typing import Dict, List, Union
+from uuid import uuid4
 
 import httpx
 
@@ -24,6 +25,16 @@ def create_s256_code_challenge(code_verifier: str) -> str:
     """Create S256 code_challenge with the given code_verifier."""
     data = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("UTF-8")
+
+
+def get_correlation_id() -> Dict[str, str]:
+    """Generate corrlation headers."""
+    correlation_id = str(uuid4())
+    return {
+        "x-identity-provider": "gcdm",
+        "x-correlation-id": correlation_id,
+        "bmw-correlation-id": correlation_id,
+    }
 
 
 def handle_http_status_error(

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -42,6 +42,8 @@ AES_KEYS = {
     }
 }
 
+HTTPX_TIMEOUT = 30.0
+
 USER_AGENT = "Dart/2.13 (dart:io)"
 X_USER_AGENT = "android(v1.07_20200330);{};2.3.0(13603)"
 

--- a/bimmer_connected/vehicle/fuel_and_battery.py
+++ b/bimmer_connected/vehicle/fuel_and_battery.py
@@ -84,10 +84,11 @@ class FuelAndBattery(VehicleDataBase):  # pylint:disable=too-many-instance-attri
         properties = vehicle_data.get("properties", {})
 
         fuel_level = properties.get("fuelLevel", {})
-        retval["remaining_fuel"] = ValueWithUnit(
-            fuel_level.get("value"),
-            fuel_level.get("units"),
-        )
+        if fuel_level:
+            retval["remaining_fuel"] = ValueWithUnit(
+                fuel_level.get("value"),
+                fuel_level.get("units"),
+            )
 
         if properties.get("fuelPercentage", {}).get("value"):
             retval["remaining_fuel_percent"] = int(properties.get("fuelPercentage", {}).get("value"))
@@ -97,7 +98,7 @@ class FuelAndBattery(VehicleDataBase):  # pylint:disable=too-many-instance-attri
             retval["is_charger_connected"] = properties["chargingState"].get("isChargerConnected", False)
 
         # Only parse ranges if vehicle has enabled LSC
-        if vehicle_data["capabilities"]["lastStateCall"]["lscState"] == "ACTIVATED":
+        if "capabilities" in vehicle_data and vehicle_data["capabilities"]["lastStateCall"]["lscState"] == "ACTIVATED":
             fuel_indicators = vehicle_data.get("status", {}).get("fuelIndicators", [])
             for indicator in fuel_indicators:
                 if (indicator.get("rangeIconId") or indicator.get("infoIconId")) == 59691:  # Combined

--- a/bimmer_connected/vehicle/location.py
+++ b/bimmer_connected/vehicle/location.py
@@ -32,7 +32,7 @@ class VehicleLocation(VehicleDataBase):
     def from_vehicle_data(cls, vehicle_data: Dict):
         """Creates the class based on vehicle data from API."""
         parsed = cls._parse_vehicle_data(vehicle_data) or {}
-        if len(parsed) > 0:
+        if len(parsed) > 1:  # must be greater than 1 due to timestamp dummy
             return cls(**parsed)
         return None
 

--- a/bimmer_connected/vehicle/models.py
+++ b/bimmer_connected/vehicle/models.py
@@ -78,6 +78,8 @@ class GPSPosition:
             return tuple(self.__iter__()) == other
         if hasattr(self, "__dict__") and hasattr(other, "__dict__"):
             return self.__dict__ == other.__dict__
+        if hasattr(self, "__dict__") and isinstance(other, Dict):
+            return self.__dict__ == other
         return False
 
 
@@ -111,19 +113,6 @@ class PointOfInterest:
         self.coordinates = GPSPosition(lat, lon)
         # pylint: disable=invalid-name
         self.locationAddress = PointOfInterestAddress(street, postal_code, city, country)
-
-
-def check_strict_types(cls):
-    """Checks a dataclass for strict typing. Use in __post_init__."""
-    for field_name, field_def in cls.__dataclass_fields__.items():  # pylint: disable=no-member
-        try:
-            original_type = field_def.type.__args__
-            field_type = original_type or field_def.type
-        except AttributeError:
-            field_type = field_def.type
-
-        if not isinstance(getattr(cls, field_name), field_type):
-            raise TypeError(f"'{field_name}' not of type '{field_def.type}'")
 
 
 class ValueWithUnit(NamedTuple):

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -118,7 +118,8 @@ async def test_login_refresh_token_row_na_expired():
             mock_listener.reset_mock()
             await account.get_vehicles()
 
-            assert mock_listener.call_count == 2
+            # Should not be called at all, as expiry date is not checked anymore
+            assert mock_listener.call_count == 0
             assert account.mybmw_client_config.authentication.refresh_token is not None
 
 
@@ -167,7 +168,8 @@ async def test_login_refresh_token_china_expired():
             mock_listener.reset_mock()
             await account.get_vehicles()
 
-            assert mock_listener.call_count == 2
+            # Should not be called at all, as expiry date is not checked anymore
+            assert mock_listener.call_count == 0
             assert account.mybmw_client_config.authentication.refresh_token is not None
 
 

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -3,7 +3,15 @@
 import datetime
 import logging
 from typing import Dict, List
-from unittest import mock
+
+try:
+    from unittest import mock
+
+    if not hasattr(mock, "AsyncMock"):
+        # AsyncMock was only introduced with Python3.8, so we have to use the backported module
+        raise ImportError()
+except ImportError:
+    import mock  # type: ignore[import,no-redef]
 
 import httpx
 import pytest

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,16 +1,10 @@
 """Tests for API that are not covered by other tests."""
-import datetime
 import json
-import sys
-from unittest import mock
 
 import pytest
-from black import asyncio
 
 from bimmer_connected.api.regions import get_region_from_name, valid_regions
 from bimmer_connected.api.utils import anonymize_data, log_to_to_file
-
-from .test_account import account_mock, get_account
 
 
 def test_valid_regions():
@@ -56,28 +50,3 @@ def test_log_to_file_without_file_name(tmp_path):
     """Test not logging to file if no file name is given."""
     assert log_to_to_file(content=[], logfile_path=tmp_path, logfile_name=None) is None
     assert len(list(tmp_path.iterdir())) == 0
-
-
-@account_mock()
-def test_asyncio_run_lock():
-    """Test calling asyncio.run() multiple times."""
-
-    with mock.patch("bimmer_connected.api.authentication.EXPIRES_AT_OFFSET", datetime.timedelta(seconds=30000)):
-        account = get_account()
-        with mock.patch(
-            "bimmer_connected.api.authentication.MyBMWAuthentication._create_or_update_lock",
-            wraps=account.mybmw_client_config.authentication._create_or_update_lock,  # pylint: disable=protected-access
-        ) as mock_listener:
-            mock_listener.reset_mock()
-
-            # Python 3.6 doesn't provide asyncio.run()
-            if sys.version_info < (3, 7):
-                for _ in range(2):
-                    loop = asyncio.new_event_loop()
-                    loop.run_until_complete(account.get_vehicles())
-                    loop.close()
-            else:
-                asyncio.run(account.get_vehicles())
-                asyncio.run(account.get_vehicles())
-
-            assert mock_listener.call_count == 4

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -3,6 +3,7 @@ import pytest
 
 from bimmer_connected.const import CarBrands
 from bimmer_connected.vehicle import DriveTrainType, VehicleViewDirection
+from bimmer_connected.vehicle.models import GPSPosition, StrEnum, VehicleDataBase
 
 from . import (
     VIN_F11,
@@ -205,3 +206,43 @@ async def test_vehicle_image(caplog):
         assert b"png_image" == await vehicle.get_vehicle_image(VehicleViewDirection.FRONT)
 
     assert len(get_deprecation_warning_count(caplog)) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_timestamp():
+    """Test no timestamp available."""
+    vehicle = (await get_mocked_account()).get_vehicle(VIN_F31)
+    vehicle._properties.pop("lastUpdatedAt")  # pylint: disable=protected-access
+    vehicle._status.pop("lastUpdatedAt")  # pylint: disable=protected-access
+
+    assert vehicle.timestamp is None
+
+
+def test_strenum():
+    """Tests StrEnum."""
+
+    class TestEnum(StrEnum):
+        """Test StrEnum."""
+
+        HELLO = "HELLO"
+
+    assert TestEnum("hello") == TestEnum.HELLO
+    assert TestEnum("HELLO") == TestEnum.HELLO
+
+    with pytest.raises(ValueError):
+        TestEnum("WORLD")
+
+
+def test_vehiclebasedata():
+    """Tests VehicleBaseData."""
+    with pytest.raises(NotImplementedError):
+        VehicleDataBase._parse_vehicle_data({})  # pylint: disable=protected-access
+
+
+def test_gpsposition():
+    """Tests around GPSPosition."""
+    pos = GPSPosition(1.0, 2.0)
+    assert pos == GPSPosition(1, 2)
+    assert pos == {"latitude": 1.0, "longitude": 2.0}
+    assert pos == (1, 2)
+    assert pos != "(1, 2)"

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -7,7 +7,8 @@ import time_machine
 
 from bimmer_connected.api.regions import get_region_from_name
 from bimmer_connected.vehicle.doors_windows import LidState, LockState
-from bimmer_connected.vehicle.fuel_and_battery import ChargingState
+from bimmer_connected.vehicle.fuel_and_battery import ChargingState, FuelAndBattery
+from bimmer_connected.vehicle.location import VehicleLocation
 from bimmer_connected.vehicle.reports import CheckControlStatus, ConditionBasedServiceStatus
 
 from . import VIN_F11, VIN_F31, VIN_F48, VIN_G01, VIN_G08, VIN_G30, VIN_I01_REX, get_deprecation_warning_count
@@ -25,16 +26,14 @@ async def test_generic(caplog):
     assert 7991 == status.mileage[0]
     assert "km" == status.mileage[1]
 
-    assert (12.3456, 34.5678) == status.vehicle_location.location
-    assert 123 == status.vehicle_location.heading
-
     assert len(get_deprecation_warning_count(caplog)) == 0
 
 
 @pytest.mark.asyncio
 async def test_range_combustion_no_info(caplog):
     """Test if the parsing of mileage and range is working"""
-    status = (await get_mocked_account()).get_vehicle(VIN_F31).fuel_and_battery
+    vehicle = (await get_mocked_account()).get_vehicle(VIN_F31)
+    status = vehicle.fuel_and_battery
 
     assert (32, "LITERS") == status.remaining_fuel
     assert status.remaining_range_fuel == (None, None)
@@ -44,6 +43,14 @@ async def test_range_combustion_no_info(caplog):
     assert status.remaining_range_electric == (None, None)
 
     assert status.remaining_range_total == (None, None)
+
+    status_from_vehicle_data = FuelAndBattery.from_vehicle_data(vehicle.data)
+    status_from_vehicle_data.account_timezone = status.account_timezone
+    assert status_from_vehicle_data == status
+    assert FuelAndBattery.from_vehicle_data({}) is None
+
+    # pylint: disable=protected-access
+    assert FuelAndBattery._parse_to_tuple({"rangeValue": "seventeen", "rangeUnit": "mi"}) == (None, None)
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 
@@ -213,6 +220,21 @@ async def test_condition_based_services(caplog):
     assert (60000, "KILOMETERS") == cbs[2].due_distance
 
     assert vehicle.condition_based_services.is_service_required is False
+
+    assert len(get_deprecation_warning_count(caplog)) == 0
+
+
+@pytest.mark.asyncio
+async def test_position_generic(caplog):
+    """Test generic attributes."""
+    status = (await get_mocked_account()).get_vehicle(VIN_G30)
+
+    assert (12.3456, 34.5678) == status.vehicle_location.location
+    assert 123 == status.vehicle_location.heading
+
+    assert VehicleLocation.from_vehicle_data(status.data).location == status.vehicle_location.location
+
+    assert VehicleLocation.from_vehicle_data({}) is None
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactors the login flow (both username/password & refresh_token) to be based on `httpx.Auth`.
This enables reacting on `HTTP 401 Unauthorized` responses and then starting the login flow again. 

This should finally fix all timing issues whatsoever, especially the ones mentioned in #428.

Also includes a graceful handle for `HTTP 429 Too Many Requests` during the login process which have come up recently.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
