### PR TITLE
Add Critical as CheckControlStatus

### DIFF
--- a/bimmer_connected/vehicle/reports.py
+++ b/bimmer_connected/vehicle/reports.py
@@ -70,6 +70,7 @@ class CheckControlStatus(StrEnum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
 
 
 @dataclass


### PR DESCRIPTION
## Proposed change
Add status Critical for CheckControlStatus based on the below error I got today after a critical message.

```
Unexpected error fetching bmw_connected_drive data: 'Critical' is not a valid CheckControlStatus
ValueError: 'Critical' is not a valid CheckControlStatus

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 191, in _async_refresh
    self.data = await self._async_update_data()
  File "/config/custom_components/bmw_connected_drive/coordinator.py", line 56, in _async_update_data
    await self.account.get_vehicles()
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/account.py", line 79, in get_vehicles
    existing_vehicle.update_state(vehicle_dict)
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/vehicle.py", line 109, in update_state
    curr_attr.update_from_vehicle_data(vehicle_data)
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/models.py", line 36, in update_from_vehicle_data
    parsed = self._parse_vehicle_data(vehicle_data) or {}
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/reports.py", line 110, in _parse_vehicle_data
    retval["messages"] = [CheckControlMessage.from_api_entry(**m) for m in messages if m["state"] != "OK"]
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/reports.py", line 110, in <listcomp>
    retval["messages"] = [CheckControlMessage.from_api_entry(**m) for m in messages if m["state"] != "OK"]
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/reports.py", line 87, in from_api_entry
    return cls(title, longDescription, CheckControlStatus(state))
  File "/usr/local/lib/python3.9/enum.py", line 384, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.9/enum.py", line 709, in __new__
    raise exc
  File "/usr/local/lib/python3.9/enum.py", line 692, in __new__
    result = cls._missing_(value)
  File "/usr/local/lib/python3.9/site-packages/bimmer_connected/vehicle/models.py", line 19, in _missing_
    raise ValueError(f"'{value}' is not a valid {cls.__name__}")
ValueError: 'Critical' is not a valid CheckControlStatus
```

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
