### PR TITLE
Force UTC in timestamps

### DIFF
--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -45,7 +45,7 @@ def parse_datetime(date_str: str) -> Optional[datetime.datetime]:
             # https://bugs.python.org/issue27400
             time_struct = time.strptime(date_str, date_format)
             parsed = datetime.datetime(*(time_struct[0:6]))
-            if time_struct.tm_gmtoff != 0:
+            if time_struct.tm_gmtoff and time_struct.tm_gmtoff != 0:
                 parsed = parsed - datetime.timedelta(seconds=time_struct.tm_gmtoff)
             parsed = parsed.replace(tzinfo=datetime.timezone.utc)
             return parsed

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -44,6 +44,7 @@ def parse_datetime(date_str: str) -> Optional[datetime.datetime]:
             # Parse datetimes using `time.strptime` to allow running in some embedded python interpreters.
             # https://bugs.python.org/issue27400
             parsed = datetime.datetime(*(time.strptime(date_str, date_format)[0:6]))
+            parsed = parsed.replace(tzinfo=datetime.timezone.utc)
             return parsed
         except ValueError:
             pass

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -43,7 +43,10 @@ def parse_datetime(date_str: str) -> Optional[datetime.datetime]:
         try:
             # Parse datetimes using `time.strptime` to allow running in some embedded python interpreters.
             # https://bugs.python.org/issue27400
-            parsed = datetime.datetime(*(time.strptime(date_str, date_format)[0:6]))
+            time_struct = time.strptime(date_str, date_format)
+            parsed = datetime.datetime(*(time_struct[0:6]))
+            if time_struct.tm_gmtoff != 0:
+                parsed = parsed - datetime.timedelta(seconds=time_struct.tm_gmtoff)
             parsed = parsed.replace(tzinfo=datetime.timezone.utc)
             return parsed
         except ValueError:

--- a/bimmer_connected/vehicle/location.py
+++ b/bimmer_connected/vehicle/location.py
@@ -38,7 +38,7 @@ class VehicleLocation(VehicleDataBase):
 
     @classmethod
     def _parse_vehicle_data(cls, vehicle_data: Dict):
-        date_dummy = datetime.datetime(1970, 1, 1)
+        date_dummy = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
         retval: Dict[str, Any] = {}
         retval["vehicle_update_timestamp"] = max(
@@ -56,7 +56,9 @@ class VehicleLocation(VehicleDataBase):
         retval = parsed
         # Overwrite vehicle data with remote service position if available & newer
         if self.remote_service_position is not None:
-            t_remote = self.remote_service_position.get("timestamp", datetime.datetime(1900, 1, 1))
+            t_remote = self.remote_service_position.get(
+                "timestamp", datetime.datetime(1900, 1, 1, tzinfo=datetime.timezone.utc)
+            )
             if t_remote > self.vehicle_update_timestamp:
                 retval["location"] = GPSPosition(
                     self.remote_service_position["latitude"], self.remote_service_position["longitude"]
@@ -77,6 +79,7 @@ class VehicleLocation(VehicleDataBase):
         else:
             pos = remote_service_dict["positionData"]["position"]
             pos["timestamp"] = datetime.datetime.utcnow()
+            pos["timestamp"] = pos["timestamp"].replace(tzinfo=datetime.timezone.utc)
 
             self.remote_service_position = pos
 

--- a/test/responses/G21/json_export.json
+++ b/test/responses/G21/json_export.json
@@ -571,7 +571,7 @@
             "longitude": 34.5678
         },
         "heading": 123,
-        "vehicle_update_timestamp": "2021-11-14T20:20:21",
+        "vehicle_update_timestamp": "2021-11-14T20:20:21+00:00",
         "account_region": "row",
         "remote_service_position": null
     },
@@ -647,7 +647,7 @@
             {
                 "service_type": "OIL",
                 "state": "OK",
-                "due_date": "2022-10-01T00:00:00",
+                "due_date": "2022-10-01T00:00:00+00:00",
                 "due_distance": [
                     6000,
                     "KILOMETERS"
@@ -656,7 +656,7 @@
             {
                 "service_type": "VEHICLE_CHECK",
                 "state": "OK",
-                "due_date": "2024-10-01T00:00:00",
+                "due_date": "2024-10-01T00:00:00+00:00",
                 "due_distance": [
                     39000,
                     "KILOMETERS"
@@ -683,7 +683,7 @@
             {
                 "service_type": "BRAKE_FLUID",
                 "state": "OK",
-                "due_date": "2023-10-01T00:00:00",
+                "due_date": "2023-10-01T00:00:00+00:00",
                 "due_distance": [
                     null,
                     null
@@ -833,6 +833,6 @@
         "km"
     ],
     "name": "330e xDrive",
-    "timestamp": "2021-11-14T20:20:21",
+    "timestamp": "2021-11-14T20:20:21+00:00",
     "vin": "some_vin_G21"
 }

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -19,7 +19,9 @@ async def test_generic(caplog):
     """Test generic attributes."""
     status = (await get_mocked_account()).get_vehicle(VIN_G30).status
 
-    expected = datetime.datetime(year=2021, month=11, day=11, hour=8, minute=58, second=53)
+    expected = datetime.datetime(
+        year=2021, month=11, day=11, hour=8, minute=58, second=53, tzinfo=datetime.timezone.utc
+    )
     assert expected == status.timestamp
 
     assert 7991 == status.mileage[0]
@@ -204,17 +206,17 @@ async def test_condition_based_services(caplog):
     cbs = status.condition_based_services
     assert 3 == len(cbs)
     assert ConditionBasedServiceStatus.OK == cbs[0].state
-    expected_cbs0 = datetime.datetime(year=2022, month=8, day=1)
+    expected_cbs0 = datetime.datetime(year=2022, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs0 == cbs[0].due_date
     assert (25000, "KILOMETERS") == cbs[0].due_distance
 
     assert ConditionBasedServiceStatus.OK == cbs[1].state
-    expected_cbs1 = datetime.datetime(year=2023, month=8, day=1)
+    expected_cbs1 = datetime.datetime(year=2023, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs1 == cbs[1].due_date
     assert (None, None) == cbs[1].due_distance
 
     assert ConditionBasedServiceStatus.OK == cbs[2].state
-    expected_cbs2 = datetime.datetime(year=2024, month=8, day=1)
+    expected_cbs2 = datetime.datetime(year=2024, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs2 == cbs[2].due_date
     assert (60000, "KILOMETERS") == cbs[2].due_distance
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -76,7 +76,7 @@ async def test_to_json(caplog):
 def test_parse_datetime(caplog):
     """Test datetime parser."""
 
-    dt_without_milliseconds = datetime.datetime(2021, 11, 12, 13, 14, 15)
+    dt_without_milliseconds = datetime.datetime(2021, 11, 12, 13, 14, 15, tzinfo=datetime.timezone.utc)
 
     assert dt_without_milliseconds == parse_datetime("2021-11-12T13:14:15.567Z")
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import os
+import sys
 import time
 from unittest import mock
 
@@ -82,7 +83,9 @@ def test_parse_datetime(caplog):
 
     assert dt_without_milliseconds == parse_datetime("2021-11-12T13:14:15Z")
 
-    assert dt_without_milliseconds == parse_datetime("2021-11-12T16:14:15+03:00")
+    if sys.version_info >= (3, 7):
+        # Don't test timezone parsing on Python 3.6 (not supported there)
+        assert dt_without_milliseconds == parse_datetime("2021-11-12T16:14:15+03:00")
 
     unparseable_datetime = "2021-14-12T13:14:15Z"
     assert parse_datetime(unparseable_datetime) is None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -82,6 +82,8 @@ def test_parse_datetime(caplog):
 
     assert dt_without_milliseconds == parse_datetime("2021-11-12T13:14:15Z")
 
+    assert dt_without_milliseconds == parse_datetime("2021-11-12T16:14:15+03:00")
+
     unparseable_datetime = "2021-14-12T13:14:15Z"
     assert parse_datetime(unparseable_datetime) is None
     errors = [r for r in caplog.records if r.levelname == "ERROR" and unparseable_datetime in r.message]

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -20,7 +20,9 @@ async def test_generic(caplog):
     """Test generic attributes."""
     status = (await get_mocked_account()).get_vehicle(VIN_G30)
 
-    expected = datetime.datetime(year=2021, month=11, day=11, hour=8, minute=58, second=53)
+    expected = datetime.datetime(
+        year=2021, month=11, day=11, hour=8, minute=58, second=53, tzinfo=datetime.timezone.utc
+    )
     assert expected == status.timestamp
 
     assert 7991 == status.mileage[0]
@@ -205,17 +207,17 @@ async def test_condition_based_services(caplog):
     cbs = vehicle.condition_based_services.messages
     assert 3 == len(cbs)
     assert ConditionBasedServiceStatus.OK == cbs[0].state
-    expected_cbs0 = datetime.datetime(year=2022, month=8, day=1)
+    expected_cbs0 = datetime.datetime(year=2022, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs0 == cbs[0].due_date
     assert (25000, "KILOMETERS") == cbs[0].due_distance
 
     assert ConditionBasedServiceStatus.OK == cbs[1].state
-    expected_cbs1 = datetime.datetime(year=2023, month=8, day=1)
+    expected_cbs1 = datetime.datetime(year=2023, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs1 == cbs[1].due_date
     assert (None, None) == cbs[1].due_distance
 
     assert ConditionBasedServiceStatus.OK == cbs[2].state
-    expected_cbs2 = datetime.datetime(year=2024, month=8, day=1)
+    expected_cbs2 = datetime.datetime(year=2024, month=8, day=1, tzinfo=datetime.timezone.utc)
     assert expected_cbs2 == cbs[2].due_date
     assert (60000, "KILOMETERS") == cbs[2].due_distance
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Force all parsed datetime values to UTC.

Due to https://github.com/bimmerconnected/bimmer_connected/discussions/422#discussioncomment-2319519 we cannot use `datetime.datetime.strptime()` but build our own logic using `time.strptime().tm_gmtoff`.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #441 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
