### PR TITLE
Ignore severity `LOW` check control messages

### DIFF
--- a/bimmer_connected/vehicle/reports.py
+++ b/bimmer_connected/vehicle/reports.py
@@ -110,6 +110,6 @@ class CheckControlMessageReport(VehicleDataBase):
         if ATTR_STATE in vehicle_data and "checkControlMessages" in vehicle_data[ATTR_STATE]:
             messages = vehicle_data[ATTR_STATE]["checkControlMessages"]
             retval["messages"] = [CheckControlMessage.from_api_entry(**m) for m in messages if m["severity"] != "OK"]
-            retval["has_check_control_messages"] = len(retval["messages"]) > 0
+            retval["has_check_control_messages"] = len([m for m in retval["messages"] if m.state != "LOW"]) > 0
 
         return retval

--- a/test/responses/G01/state_WBA00000000DEMO04_0.json
+++ b/test/responses/G01/state_WBA00000000DEMO04_0.json
@@ -93,7 +93,7 @@
         },
         "checkControlMessages": [
             {
-                "severity": "LOW",
+                "severity": "MEDIUM",
                 "type": "ENGINE_OIL"
             }
         ],

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -287,7 +287,7 @@ async def test_check_control_messages(caplog):
     ccms = vehicle.status.check_control_messages
     assert 1 == len(ccms)
 
-    assert CheckControlStatus.LOW == ccms[0].state
+    assert CheckControlStatus.MEDIUM == ccms[0].state
     assert "ENGINE_OIL" == ccms[0].description_short
     assert None is ccms[0].description_long
 

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -244,6 +244,7 @@ def test_vehiclebasedata():
         {"state": {"checkControlMessages": [{"severity": "LOW", "type": "ENGINE_OIL"}]}}
     )
     assert len(ccmr.messages) == 1
+    assert ccmr.has_check_control_messages is False
 
 
 def test_gpsposition():

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -322,6 +322,16 @@ async def test_check_control_messages(caplog):
     ccms = vehicle.check_control_messages.messages
     assert 1 == len(ccms)
 
+    assert CheckControlStatus.MEDIUM == ccms[0].state
+    assert "ENGINE_OIL" == ccms[0].description_short
+    assert None is ccms[0].description_long
+
+    vehicle = (await get_mocked_account()).get_vehicle(VIN_G20)
+    assert vehicle.check_control_messages.has_check_control_messages is False
+
+    ccms = vehicle.check_control_messages.messages
+    assert 1 == len(ccms)
+
     assert CheckControlStatus.LOW == ccms[0].state
     assert "ENGINE_OIL" == ccms[0].description_short
     assert None is ccms[0].description_long


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ignores severity `LOW` for the number of check control messages (used for the HA binary sensor), but still keeps them available (for use in the binary sensor attributes).


## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: https://github.com/home-assistant/core/issues/74568

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
