### PR TITLE
Fix `remaining_range_total` on new electric-only vehicles

### DIFF
--- a/bimmer_connected/vehicle/__init__.py
+++ b/bimmer_connected/vehicle/__init__.py
@@ -1,3 +1,4 @@
 """Methods and classes around the vehicle."""
 
-from .vehicle import ConnectedDriveVehicle, DriveTrainType, MyBMWVehicle, VehicleViewDirection  # noqa
+from .const import DriveTrainType  # noqa
+from .vehicle import ConnectedDriveVehicle, MyBMWVehicle, VehicleViewDirection  # noqa

--- a/bimmer_connected/vehicle/const.py
+++ b/bimmer_connected/vehicle/const.py
@@ -1,0 +1,32 @@
+"""Vehicle-wide constants used by multiple data models."""
+
+from bimmer_connected.models import StrEnum
+
+
+class DriveTrainType(StrEnum):
+    """Different types of drive trains."""
+
+    COMBUSTION = "COMBUSTION"
+    PLUGIN_HYBRID = "PLUGIN_HYBRID"  # PHEV
+    ELECTRIC = "ELECTRIC"
+    ELECTRIC_WITH_RANGE_EXTENDER = "ELECTRIC_WITH_RANGE_EXTENDER"
+    HYBRID = "HYBRID"  # mild hybrids (MyBMW API v1)
+    MILD_HYBRID = "MILD_HYBRID"  # mild hybrids (MyBMW API v2)
+    UNKNOWN = "UNKNOWN"
+
+
+#: Set of drive trains that have a combustion engine
+COMBUSTION_ENGINE_DRIVE_TRAINS = {
+    DriveTrainType.COMBUSTION,
+    DriveTrainType.ELECTRIC_WITH_RANGE_EXTENDER,
+    DriveTrainType.PLUGIN_HYBRID,
+    DriveTrainType.HYBRID,
+    DriveTrainType.MILD_HYBRID,
+}
+
+#: set of drive trains that have a high voltage battery
+HV_BATTERY_DRIVE_TRAINS = {
+    DriveTrainType.PLUGIN_HYBRID,
+    DriveTrainType.ELECTRIC,
+    DriveTrainType.ELECTRIC_WITH_RANGE_EXTENDER,
+}

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -8,6 +8,7 @@ from bimmer_connected.const import ATTR_ATTRIBUTES, ATTR_CAPABILITIES, ATTR_STAT
 from bimmer_connected.models import StrEnum, ValueWithUnit
 from bimmer_connected.utils import deprecated, parse_datetime
 from bimmer_connected.vehicle.charging_profile import ChargingProfile
+from bimmer_connected.vehicle.const import COMBUSTION_ENGINE_DRIVE_TRAINS, HV_BATTERY_DRIVE_TRAINS, DriveTrainType
 from bimmer_connected.vehicle.doors_windows import DoorsAndWindows
 from bimmer_connected.vehicle.fuel_and_battery import FuelAndBattery
 from bimmer_connected.vehicle.location import VehicleLocation
@@ -21,34 +22,6 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class DriveTrainType(StrEnum):
-    """Different types of drive trains."""
-
-    COMBUSTION = "COMBUSTION"
-    PLUGIN_HYBRID = "PLUGIN_HYBRID"  # PHEV
-    ELECTRIC = "ELECTRIC"
-    ELECTRIC_WITH_RANGE_EXTENDER = "ELECTRIC_WITH_RANGE_EXTENDER"
-    HYBRID = "HYBRID"  # mild hybrids (MyBMW API v1)
-    MILD_HYBRID = "MILD_HYBRID"  # mild hybrids (MyBMW API v2)
-    UNKNOWN = "UNKNOWN"
-
-
-#: Set of drive trains that have a combustion engine
-COMBUSTION_ENGINE_DRIVE_TRAINS = {
-    DriveTrainType.COMBUSTION,
-    DriveTrainType.PLUGIN_HYBRID,
-    DriveTrainType.HYBRID,
-    DriveTrainType.MILD_HYBRID,
-}
-
-#: set of drive trains that have a high voltage battery
-HV_BATTERY_DRIVE_TRAINS = {
-    DriveTrainType.PLUGIN_HYBRID,
-    DriveTrainType.ELECTRIC,
-    DriveTrainType.ELECTRIC_WITH_RANGE_EXTENDER,
-}
 
 
 class VehicleViewDirection(StrEnum):

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -152,13 +152,6 @@ class MyBMWVehicle:
         return self.drive_train in HV_BATTERY_DRIVE_TRAINS
 
     @property
-    def has_range_extender_drivetrain(self) -> bool:
-        """Return True if vehicle is equipped with a range extender.
-
-        In this case we can get the state of the gas tank."""
-        return self.drive_train == DriveTrainType.ELECTRIC_WITH_RANGE_EXTENDER
-
-    @property
     def has_combustion_drivetrain(self) -> bool:
         """Return True if vehicle is equipped with an internal combustion engine.
 
@@ -218,7 +211,7 @@ class MyBMWVehicle:
                 "remaining_range_electric",
                 "last_charging_end_result",
             ]
-        if self.has_combustion_drivetrain or self.has_range_extender_drivetrain:
+        if self.has_combustion_drivetrain:
             result += ["remaining_fuel", "remaining_range_fuel", "remaining_fuel_percent"]
         return result
 
@@ -269,10 +262,10 @@ class MyBMWVehicle:
         return self.has_electric_drivetrain
 
     @property  # type: ignore[misc]
-    @deprecated("vehicle.has_range_extender_drivetrain")
+    @deprecated()
     def has_range_extender(self) -> bool:
         # pylint:disable=missing-function-docstring
-        return self.has_range_extender_drivetrain
+        return False
 
     @property  # type: ignore[misc]
     @deprecated("vehicle.has_combustion_drivetrain")

--- a/test/responses/I20/state_WBA00000000DEMO01_0.json
+++ b/test/responses/I20/state_WBA00000000DEMO01_0.json
@@ -134,9 +134,7 @@
             }
         ],
         "combustionFuelLevel": {
-            "range": 0,
-            "remainingFuelLiters": 0,
-            "remainingFuelPercent": 10
+            "range": 504
         },
         "currentMileage": 1121,
         "doorsState": {

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -107,15 +107,15 @@ def account_mock():
     return router
 
 
-def get_account(region=None):
+def get_account(region: Regions = None, metric: bool = True):
     """Returns account without token and vehicles (sync)."""
-    return MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION)
+    return MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION, use_metric_units=metric)
 
 
-async def get_mocked_account(region=None):
+async def get_mocked_account(region: Regions = None, metric: bool = True):
     """Returns pre-mocked account."""
     with account_mock():
-        account = get_account(region)
+        account = get_account(region, metric)
         await account.get_vehicles()
     return account
 

--- a/test/test_deprecated_vehicle.py
+++ b/test/test_deprecated_vehicle.py
@@ -54,7 +54,7 @@ async def test_drive_train_attributes(caplog):
         VIN_G20: (True, False, False),
         VIN_G23: (False, True, False),
         VIN_I01_NOREX: (False, True, False),
-        VIN_I01_REX: (False, True, True),
+        VIN_I01_REX: (True, True, True),
         VIN_I20: (False, True, False),
     }
 

--- a/test/test_deprecated_vehicle.py
+++ b/test/test_deprecated_vehicle.py
@@ -54,7 +54,7 @@ async def test_drive_train_attributes(caplog):
         VIN_G20: (True, False, False),
         VIN_G23: (False, True, False),
         VIN_I01_NOREX: (False, True, False),
-        VIN_I01_REX: (True, True, True),
+        VIN_I01_REX: (True, True, False),
         VIN_I20: (False, True, False),
     }
 

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -114,9 +114,9 @@ async def test_range_electric(caplog):
     """Test if the parsing of mileage and range is working"""
     status = (await get_mocked_account()).get_vehicle(VIN_G23).status
 
-    assert (0, "L") == status.remaining_fuel
-    assert status.remaining_range_fuel == (0, "km")
-    assert status.fuel_percent == 0
+    assert status.remaining_fuel == (None, None)
+    assert status.remaining_range_fuel == (None, None)
+    assert status.fuel_percent is None
 
     assert 80 == status.charging_level_hv
     assert (472, "km") == status.remaining_range_electric

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -32,7 +32,6 @@ async def test_drive_train():
         "has_hv_battery",
         "has_internal_combustion_engine",
         "has_range_extender",
-        "has_range_extender_drivetrain",
         "has_weekly_planner_service",
         "is_charging_plan_supported",
         "is_lsc_enabled",

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -3,7 +3,8 @@ import pytest
 
 from bimmer_connected.const import ATTR_ATTRIBUTES, ATTR_STATE, CarBrands
 from bimmer_connected.models import GPSPosition, StrEnum, VehicleDataBase
-from bimmer_connected.vehicle import DriveTrainType, VehicleViewDirection
+from bimmer_connected.vehicle import VehicleViewDirection
+from bimmer_connected.vehicle.const import DriveTrainType
 from bimmer_connected.vehicle.reports import CheckControlMessageReport
 
 from . import VIN_F31, VIN_G01, VIN_G20, VIN_G23, VIN_I01_NOREX, VIN_I01_REX, VIN_I20, get_deprecation_warning_count
@@ -77,7 +78,7 @@ async def test_drive_train_attributes(caplog):
         VIN_G20: (True, False, False),
         VIN_G23: (False, True, False),
         VIN_I01_NOREX: (False, True, False),
-        VIN_I01_REX: (False, True, True),
+        VIN_I01_REX: (True, True, True),
         VIN_I20: (False, True, False),
     }
 

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -73,19 +73,18 @@ async def test_drive_train_attributes(caplog):
     account = await get_mocked_account()
 
     vehicle_drivetrains = {
-        VIN_F31: (True, False, False),
-        VIN_G01: (True, True, False),
-        VIN_G20: (True, False, False),
-        VIN_G23: (False, True, False),
-        VIN_I01_NOREX: (False, True, False),
-        VIN_I01_REX: (True, True, True),
-        VIN_I20: (False, True, False),
+        VIN_F31: (True, False),
+        VIN_G01: (True, True),
+        VIN_G20: (True, False),
+        VIN_G23: (False, True),
+        VIN_I01_NOREX: (False, True),
+        VIN_I01_REX: (True, True),
+        VIN_I20: (False, True),
     }
 
     for vehicle in account.vehicles:
         assert vehicle_drivetrains[vehicle.vin][0] == vehicle.has_combustion_drivetrain
         assert vehicle_drivetrains[vehicle.vin][1] == vehicle.has_electric_drivetrain
-        assert vehicle_drivetrains[vehicle.vin][2] == vehicle.has_range_extender_drivetrain
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -11,7 +11,7 @@ from bimmer_connected.vehicle.fuel_and_battery import ChargingState, FuelAndBatt
 from bimmer_connected.vehicle.location import VehicleLocation
 from bimmer_connected.vehicle.reports import CheckControlStatus, ConditionBasedServiceStatus
 
-from . import VIN_F31, VIN_G01, VIN_G20, VIN_G23, VIN_I01_NOREX, VIN_I01_REX, get_deprecation_warning_count
+from . import VIN_F31, VIN_G01, VIN_G20, VIN_G23, VIN_I01_NOREX, VIN_I01_REX, VIN_I20, get_deprecation_warning_count
 from .test_account import get_mocked_account
 
 
@@ -55,6 +55,7 @@ async def test_range_combustion_no_info(caplog):
 @pytest.mark.asyncio
 async def test_range_combustion(caplog):
     """Test if the parsing of mileage and range is working"""
+    # Metric units
     status = (await get_mocked_account()).get_vehicle(VIN_G20).fuel_and_battery
 
     assert (40, "L") == status.remaining_fuel
@@ -68,10 +69,25 @@ async def test_range_combustion(caplog):
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 
+    # Imperial units
+    status = (await get_mocked_account(metric=False)).get_vehicle(VIN_G20).fuel_and_battery
+
+    assert (40, "gal") == status.remaining_fuel
+    assert (629, "mi") == status.remaining_range_fuel
+    assert status.remaining_fuel_percent == 80
+
+    assert status.remaining_battery_percent is None
+    assert status.remaining_range_electric == (None, None)
+
+    assert (629, "mi") == status.remaining_range_total
+
+    assert len(get_deprecation_warning_count(caplog)) == 0
+
 
 @pytest.mark.asyncio
 async def test_range_phev(caplog):
     """Test if the parsing of mileage and range is working"""
+    # Metric units
     status = (await get_mocked_account()).get_vehicle(VIN_G01).fuel_and_battery
 
     assert (40, "L") == status.remaining_fuel
@@ -87,10 +103,27 @@ async def test_range_phev(caplog):
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 
+    # Imperial units
+    status = (await get_mocked_account(metric=False)).get_vehicle(VIN_G01).fuel_and_battery
+
+    assert (40, "gal") == status.remaining_fuel
+    assert (476, "mi") == status.remaining_range_fuel
+    assert 80 == status.remaining_fuel_percent
+
+    assert 80 == status.remaining_battery_percent
+    assert (40, "mi") == status.remaining_range_electric
+
+    assert (516, "mi") == status.remaining_range_total
+
+    assert status.remaining_range_fuel[0] + status.remaining_range_electric[0] == status.remaining_range_total[0]
+
+    assert len(get_deprecation_warning_count(caplog)) == 0
+
 
 @pytest.mark.asyncio
 async def test_range_rex(caplog):
     """Test if the parsing of mileage and range is working"""
+    # Metric units
     status = (await get_mocked_account()).get_vehicle(VIN_I01_REX).fuel_and_battery
 
     assert (6, "L") == status.remaining_fuel
@@ -106,20 +139,51 @@ async def test_range_rex(caplog):
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 
+    # Imperial units
+    status = (await get_mocked_account(metric=False)).get_vehicle(VIN_I01_REX).fuel_and_battery
+
+    assert (6, "gal") == status.remaining_fuel
+    assert (105, "mi") == status.remaining_range_fuel
+    assert status.remaining_fuel_percent is None
+
+    assert 82 == status.remaining_battery_percent
+    assert (174, "mi") == status.remaining_range_electric
+
+    assert (279, "mi") == status.remaining_range_total
+
+    assert status.remaining_range_fuel[0] + status.remaining_range_electric[0] == status.remaining_range_total[0]
+
+    assert len(get_deprecation_warning_count(caplog)) == 0
+
 
 @pytest.mark.asyncio
 async def test_range_electric(caplog):
     """Test if the parsing of mileage and range is working"""
-    status = (await get_mocked_account()).get_vehicle(VIN_G23).fuel_and_battery
+    # Metric units
+    status = (await get_mocked_account()).get_vehicle(VIN_I20).fuel_and_battery
 
-    assert (0, "L") == status.remaining_fuel
-    assert status.remaining_range_fuel == (0, "km")
-    assert status.remaining_fuel_percent == 0
+    assert status.remaining_fuel == (None, None)
+    assert status.remaining_range_fuel == (None, None)
+    assert status.remaining_fuel_percent is None
 
     assert 80 == status.remaining_battery_percent
-    assert (472, "km") == status.remaining_range_electric
+    assert (504, "km") == status.remaining_range_electric
 
-    assert (472, "km") == status.remaining_range_total
+    assert (504, "km") == status.remaining_range_total
+
+    assert len(get_deprecation_warning_count(caplog)) == 0
+
+    # Imperial units
+    status = (await get_mocked_account(metric=False)).get_vehicle(VIN_I20).fuel_and_battery
+
+    assert status.remaining_fuel == (None, None)
+    assert status.remaining_range_fuel == (None, None)
+    assert status.remaining_fuel_percent is None
+
+    assert 80 == status.remaining_battery_percent
+    assert (504, "mi") == status.remaining_range_electric
+
+    assert (504, "mi") == status.remaining_range_total
 
     assert len(get_deprecation_warning_count(caplog)) == 0
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes doubled `remaining_range_total` on newer electric only vehicles.

As parsing had to be based on `DriveTrainType`, some refactoring had to be done (mainly moving `DriveTrainType` into a separate file to avoid circular imports).

While implementing, it became clear that we do not need a separate attribute for range extender cars, so I removed that as well.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/74703

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
