### PR TITLE
Fix CBS `due_date` typing

### DIFF
--- a/bimmer_connected/vehicle/reports.py
+++ b/bimmer_connected/vehicle/reports.py
@@ -27,7 +27,7 @@ class ConditionBasedService:  # pylint: disable=too-few-public-methods
 
     service_type: str
     state: ConditionBasedServiceStatus
-    due_date: Optional[datetime.date]
+    due_date: Optional[datetime.datetime]
     due_distance: ValueWithUnit
 
     # pylint:disable=invalid-name,redefined-builtin,too-many-arguments,unused-argument


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During some testing, I (or rather mypy) figured out a small typing issue.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
