### PR TITLE
Reduce API calls

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -81,13 +81,13 @@ class MyBMWAccount:  # pylint: disable=too-many-instance-attributes
                 for vehicle_base in response.json():
                     self.add_vehicle(vehicle_base, {}, fetched_at)
 
-    async def get_vehicles(self) -> None:
+    async def get_vehicles(self, force_init: bool = False) -> None:
         """Retrieve vehicle data from BMW servers."""
         _LOGGER.debug("Getting vehicle list")
 
         fetched_at = datetime.datetime.now(datetime.timezone.utc)
 
-        if len(self.vehicles) == 0:
+        if len(self.vehicles) == 0 or force_init:
             await self._init_vehicles()
 
         async with MyBMWClient(self.config) as client:

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -59,8 +59,8 @@ class MyBMWAccount:  # pylint: disable=too-many-instance-attributes
                 use_metric_units=use_metric_units,
             )
 
-    async def get_vehicles(self) -> None:
-        """Retrieve vehicle data from BMW servers."""
+    async def _init_vehicles(self) -> None:
+        """Initialize vehicles from BMW servers."""
         _LOGGER.debug("Getting vehicle list")
 
         fetched_at = datetime.datetime.now(datetime.timezone.utc)
@@ -79,14 +79,29 @@ class MyBMWAccount:  # pylint: disable=too-many-instance-attributes
 
             for response in vehicles_responses:
                 for vehicle_base in response.json():
-                    # Get the detailed vehicle state
-                    state_response = await client.get(
-                        VEHICLE_STATE_URL.format(vin=vehicle_base["vin"]),
-                        headers=response.request.headers,  # Reuse the same headers as used to get vehicle list
-                    )
-                    vehicle_state = state_response.json()
+                    self.add_vehicle(vehicle_base, {}, fetched_at)
 
-                    self.add_vehicle(vehicle_base, vehicle_state, fetched_at)
+    async def get_vehicles(self) -> None:
+        """Retrieve vehicle data from BMW servers."""
+        _LOGGER.debug("Getting vehicle list")
+
+        fetched_at = datetime.datetime.now(datetime.timezone.utc)
+
+        if len(self.vehicles) == 0:
+            await self._init_vehicles()
+
+        async with MyBMWClient(self.config) as client:
+            for vehicle in self.vehicles:
+                # Get the detailed vehicle state
+                state_response = await client.get(
+                    VEHICLE_STATE_URL.format(vin=vehicle.vin),
+                    headers={
+                        **client.generate_default_header(vehicle.brand),
+                        "bmw-current-date": fetched_at.isoformat(),
+                    },
+                )
+                vehicle_state = state_response.json()
+                self.add_vehicle(vehicle.data, vehicle_state, fetched_at)
 
     async def get_fingerprints(self) -> Dict[str, Any]:
         """Retrieve vehicle data from BMW servers and return original responses as JSON."""

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -160,7 +160,7 @@ async def test_login_refresh_token_row_na_401():
             "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_row_na",
             wraps=account.config.authentication._refresh_token_row_na,  # pylint: disable=protected-access
         ) as mock_listener:
-            mock_api.get("/eadrax-vcs/v2/vehicles").mock(
+            mock_api.get(path__regex=r"^/eadrax-vcs/v2/vehicles/(?P<vin>\w+)/state").mock(
                 side_effect=[httpx.Response(401), *([httpx.Response(200, json=[])] * 10)]
             )
             mock_listener.reset_mock()
@@ -233,7 +233,7 @@ async def test_login_refresh_token_china_401():
             "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_china",
             wraps=account.config.authentication._refresh_token_china,  # pylint: disable=protected-access
         ) as mock_listener:
-            mock_api.get("/eadrax-vcs/v2/vehicles").mock(
+            mock_api.get(path__regex=r"^/eadrax-vcs/v2/vehicles/(?P<vin>\w+)/state").mock(
                 side_effect=[httpx.Response(401), *([httpx.Response(200, json=[])] * 10)]
             )
             mock_listener.reset_mock()
@@ -336,7 +336,7 @@ async def test_storing_fingerprints(tmp_path):
         account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION, log_responses=tmp_path)
         await account.get_vehicles()
 
-        mock_api.get("/eadrax-vcs/v2/vehicles").respond(
+        mock_api.get(path__regex=r"^/eadrax-vcs/v2/vehicles/(?P<vin>\w+)/state").respond(
             500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
         )
         with pytest.raises(httpx.HTTPStatusError):

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -282,6 +282,32 @@ async def test_vehicles():
     assert account.get_vehicle("invalid_vin") is None
 
 
+@account_mock()
+@pytest.mark.asyncio
+async def test_vehicle_init():
+    """Test vehicle initialization."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+    with mock.patch(
+        "bimmer_connected.account.MyBMWAccount._init_vehicles",
+        wraps=account._init_vehicles,  # pylint: disable=protected-access
+    ) as mock_listener:
+        mock_listener.reset_mock()
+
+        # First call on init
+        await account.get_vehicles()
+        assert len(account.vehicles) == get_fingerprint_count()
+
+        # No call to _init_vehicles()
+        await account.get_vehicles()
+        assert len(account.vehicles) == get_fingerprint_count()
+
+        # Second, forced call _init_vehicles()
+        await account.get_vehicles(force_init=True)
+        assert len(account.vehicles) == get_fingerprint_count()
+
+        assert mock_listener.call_count == 2
+
+
 @pytest.mark.asyncio
 async def test_invalid_password():
     """Test parsing the results of an invalid password."""


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`MyBMWAccount.get_vehicles()` will by default get the vehicle list on initialization only. If new vehicles are added to your account, re-initialize `MyBMWAccount` or call `get_vehicles(force_init=True)`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Access the `/vehicles` endpoint only on init to reduce number of calls (2 of 3 API calls with one car).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/78792, https://github.com/bimmerconnected/bimmer_connected/issues/485

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
