### PR TITLE
Support Python 3.11, drop tests for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.x"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.x"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10.x"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         args:
@@ -8,7 +8,7 @@ repos:
           - --quiet
         files: ^((bimmer_connected|test)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.2.2
     hooks:
       - id: codespell
         args:
@@ -22,13 +22,13 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - pycodestyle==2.9.1
-          - pyflakes==2.5.0
-          - flake8-docstrings==1.6.0
-          - pydocstyle==6.1.1
-          - flake8-comprehensions==3.10.0
-          - flake8-noqa==1.2.9
-          - mccabe==0.7.0
+          - pycodestyle
+          - pyflakes
+          - flake8-docstrings
+          - pydocstyle
+          - flake8-comprehensions
+          - flake8-noqa
+          - mccabe
         files: ^(bimmer_connected|test)/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
@@ -36,7 +36,7 @@ repos:
       - id: isort
         files: ^(bimmer_connected|test)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.990
     hooks: 
       - id: mypy
         name: mypy

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ the MyBMW portal.
 
 Installation
 ============
-:code:`bimmer_connected` requires **Python 3.6 or above**. Just install the latest release from `PyPI <https://pypi.org/project/bimmer-connected/>`_ 
+:code:`bimmer_connected` is tested against **Python 3.7 or above**. Just install the latest release from `PyPI <https://pypi.org/project/bimmer-connected/>`_ 
 using :code:`pip3 install --upgrade bimmer_connected`. 
 
 Alteratively, clone the project and execute :code:`pip install -e .` to install the current 

--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -100,7 +100,9 @@ class MyBMWAccount:  # pylint: disable=too-many-instance-attributes
                 vehicle_state = state_response.json()
                 self.add_vehicle(vehicle.data, vehicle_state, fetched_at)
 
-    def add_vehicle(self, vehicle_base: dict, vehicle_state: dict, fetched_at: datetime.datetime = None) -> None:
+    def add_vehicle(
+        self, vehicle_base: dict, vehicle_state: dict, fetched_at: Optional[datetime.datetime] = None
+    ) -> None:
         """Add or update a vehicle from the API responses."""
 
         existing_vehicle = self.get_vehicle(vehicle_base["vin"])

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -34,7 +34,7 @@ class MyBMWClientConfiguration:
 class MyBMWClient(httpx.AsyncClient):
     """Async HTTP client based on `httpx.AsyncClient` with automated OAuth token refresh."""
 
-    def __init__(self, config: MyBMWClientConfiguration, *args, brand: CarBrands = None, **kwargs):
+    def __init__(self, config: MyBMWClientConfiguration, *args, brand: Optional[CarBrands] = None, **kwargs):
         self.config = config
 
         # Add authentication
@@ -72,7 +72,7 @@ class MyBMWClient(httpx.AsyncClient):
 
         super().__init__(*args, **kwargs)
 
-    def generate_default_header(self, brand: CarBrands = None) -> Dict[str, str]:
+    def generate_default_header(self, brand: Optional[CarBrands] = None) -> Dict[str, str]:
         """Generate a header for HTTP requests to the server."""
         return {
             "accept": "application/json",

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -79,7 +79,7 @@ class MyBMWClient(httpx.AsyncClient):
             "accept-language": "en",
             "user-agent": USER_AGENT,
             "x-user-agent": X_USER_AGENT.format(
-                brand=(brand or CarBrands.BMW),
+                brand=(brand or CarBrands.BMW).value,
                 app_version=get_app_version(self.config.authentication.region),
                 region=self.config.authentication.region.value,
             ),

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -8,7 +8,7 @@ import mimetypes
 import random
 import re
 import string
-from typing import Dict, List, Match, Union
+from typing import Dict, List, Optional, Union
 from uuid import uuid4
 
 import httpx
@@ -43,7 +43,10 @@ def get_correlation_id() -> Dict[str, str]:
 
 
 def handle_http_status_error(
-    ex: httpx.HTTPStatusError, module: str = "MyBMW API", log_handler: logging.Logger = None, debug: bool = False
+    ex: httpx.HTTPStatusError,
+    module: str = "MyBMW API",
+    log_handler: Optional[logging.Logger] = None,
+    debug: bool = False,
 ) -> None:
     """Try to extract information from response and re-raise Exception."""
     _logger = log_handler or logging.getLogger(__name__)

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -94,7 +94,7 @@ def anonymize_data(json_data: Union[List, Dict]) -> Union[List, Dict]:
     return json_data
 
 
-def anonymize_vin(match: Match):
+def anonymize_vin(match: re.Match):
     """Anonymize VINs but keep assignment."""
     vin = match.groupdict()["vin"]
     if vin not in ANONYMIZED_VINS:

--- a/bimmer_connected/vehicle/location.py
+++ b/bimmer_connected/vehicle/location.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class VehicleLocation(VehicleDataBase):
     """The current position of a vehicle."""
 
-    location: GPSPosition = GPSPosition(None, None)
+    location: Optional[GPSPosition] = None
     """The last known position of the vehicle."""
 
     heading: Optional[int] = None

--- a/bimmer_connected/vehicle/remote_services.py
+++ b/bimmer_connected/vehicle/remote_services.py
@@ -4,7 +4,7 @@ import asyncio
 import datetime
 import json
 import logging
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from bimmer_connected.api.client import MyBMWClient
 from bimmer_connected.const import (
@@ -140,13 +140,13 @@ class RemoteServices:
         await self._trigger_state_update()
         return result
 
-    async def trigger_remote_service(self, service_id: Services, params: Dict = None) -> RemoteServiceStatus:
+    async def trigger_remote_service(self, service_id: Services, params: Optional[Dict] = None) -> RemoteServiceStatus:
         """Trigger a generic remote service and wait for the result."""
         event_id = await self._start_remote_service(service_id, params)
         status = await self._block_until_done(event_id)
         return status
 
-    async def _start_remote_service(self, service_id: Services, params: Dict = None) -> str:
+    async def _start_remote_service(self, service_id: Services, params: Optional[Dict] = None) -> str:
         """Start a generic remote service."""
 
         url = REMOTE_SERVICE_URL.format(vin=self._vehicle.vin, service_type=service_id.value)
@@ -173,7 +173,7 @@ class RemoteServices:
             f"Current state: {status.state.value}"
         )
 
-    async def _get_remote_service_status(self, event_id: str = None) -> RemoteServiceStatus:
+    async def _get_remote_service_status(self, event_id: str) -> RemoteServiceStatus:
         """The execution status of the last remote service that was triggered."""
         _LOGGER.debug("getting remote service status for '%s'", event_id)
         url = REMOTE_SERVICE_STATUS_URL.format(vin=self._vehicle.vin, event_id=event_id)

--- a/bimmer_connected/vehicle/reports.py
+++ b/bimmer_connected/vehicle/reports.py
@@ -33,7 +33,13 @@ class ConditionBasedService:  # pylint: disable=too-few-public-methods
     # pylint:disable=invalid-name,redefined-builtin,too-many-arguments,unused-argument
     @classmethod
     def from_api_entry(
-        cls, type: str, status: str, dateTime: str = None, mileage: int = None, is_metric: bool = True, **kwargs
+        cls,
+        type: str,
+        status: str,
+        dateTime: Optional[str] = None,
+        mileage: Optional[int] = None,
+        is_metric: bool = True,
+        **kwargs
     ):
         """Parse a condition based service entry from the API format to `ConditionBasedService`."""
         due_distance = ValueWithUnit(mileage, "km" if is_metric else "mi") if mileage else ValueWithUnit(None, None)
@@ -87,7 +93,7 @@ class CheckControlMessage:
 
     # pylint:disable=invalid-name,redefined-builtin,unused-argument
     @classmethod
-    def from_api_entry(cls, type: str, severity: str, longDescription: str = None, **kwargs):
+    def from_api_entry(cls, type: str, severity: str, longDescription: Optional[str] = None, **kwargs):
         """Parses a check control entry from the API format to `CheckControlMessage`."""
         return cls(type, longDescription, CheckControlStatus(severity))
 

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -62,7 +62,11 @@ class MyBMWVehicle:
     """
 
     def __init__(
-        self, account: "MyBMWAccount", vehicle_base: dict, vehicle_state: dict, fetched_at: datetime.datetime = None
+        self,
+        account: "MyBMWAccount",
+        vehicle_base: dict,
+        vehicle_state: dict,
+        fetched_at: Optional[datetime.datetime] = None,
     ) -> None:
         """Initializes a MyBMWVehicle."""
         self.account = account
@@ -78,7 +82,9 @@ class MyBMWVehicle:
 
         self.update_state(vehicle_base, vehicle_state, fetched_at)
 
-    def update_state(self, vehicle_base: dict, vehicle_state: dict, fetched_at: datetime.datetime = None) -> None:
+    def update_state(
+        self, vehicle_base: dict, vehicle_state: dict, fetched_at: Optional[datetime.datetime] = None
+    ) -> None:
         """Update the state of a vehicle."""
         vehicle_data = self.combine_data(self.account, vehicle_base, vehicle_state or {}, fetched_at)
         self.data = vehicle_data
@@ -100,7 +106,7 @@ class MyBMWVehicle:
 
     @staticmethod
     def combine_data(
-        account: "MyBMWAccount", vehicle_base: dict, vehicle_state: dict, fetched_at: datetime.datetime = None
+        account: "MyBMWAccount", vehicle_base: dict, vehicle_state: dict, fetched_at: Optional[datetime.datetime] = None
     ) -> Dict:
         """Combine API responses and additional information to a single dictionary."""
         return {
@@ -304,7 +310,7 @@ class ConnectedDriveVehicle(MyBMWVehicle):
         super().__init__(account, vehicle_dict, {})
 
     def update_state(
-        self, vehicle_base: dict, vehicle_state: dict = None, fetched_at: datetime.datetime = None
+        self, vehicle_base: dict, vehicle_state: Optional[dict] = None, fetched_at: Optional[datetime.datetime] = None
     ) -> None:
         """Update the state of a vehicle."""
 

--- a/bimmer_connected/vehicle/vehicle_status.py
+++ b/bimmer_connected/vehicle/vehicle_status.py
@@ -32,7 +32,7 @@ class VehicleStatus:  # pylint: disable=too-many-public-methods
 
     @property  # type: ignore[misc]
     @deprecated("vehicle.vehicle_location.location")
-    def gps_position(self) -> GPSPosition:
+    def gps_position(self) -> Optional[GPSPosition]:
         # pylint:disable=missing-function-docstring
         return self.vehicle.vehicle_location.location
 

--- a/bimmer_connected/vehicle/vehicle_status.py
+++ b/bimmer_connected/vehicle/vehicle_status.py
@@ -20,7 +20,7 @@ class VehicleStatus:  # pylint: disable=too-many-public-methods
     """Models the status of a vehicle."""
 
     # pylint: disable=unused-argument
-    def __init__(self, vehicle: "MyBMWVehicle", status_dict: Dict = None):
+    def __init__(self, vehicle: "MyBMWVehicle", status_dict: Optional[Dict] = None):
         """Constructor."""
         self.vehicle = vehicle
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,7 +10,6 @@ flake8
 mypy
 types-setuptools
 pbr
-time_machine>=2.7.1;python_version>="3.7"
-time_machine~=2.5.0;python_version<"3.7"
+time_machine
 pre-commit
 backports.zoneinfo;python_version<"3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,11 @@ classifier =
     Environment :: Console
     Intended Audience :: Developers
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 keywords =
     BMW
     Connected Drive

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -64,7 +64,7 @@ def vehicles_sideeffect(request: httpx.Request) -> httpx.Response:
     # Test if given region is valid
     _ = Regions(x_user_agent[3])
 
-    return httpx.Response(200, json=ALL_FINGERPRINTS.get(brand.value, []))
+    return httpx.Response(200, json=ALL_FINGERPRINTS.get(brand, []))
 
 
 def vehicle_state_sideeffect(request: httpx.Request, vin: str) -> httpx.Response:

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 from pathlib import Path
+from typing import Optional
 
 try:
     from unittest import mock
@@ -63,7 +64,7 @@ def vehicles_sideeffect(request: httpx.Request) -> httpx.Response:
     # Test if given region is valid
     _ = Regions(x_user_agent[3])
 
-    return httpx.Response(200, json=ALL_FINGERPRINTS.get(brand, []))
+    return httpx.Response(200, json=ALL_FINGERPRINTS.get(brand.value, []))
 
 
 def vehicle_state_sideeffect(request: httpx.Request, vin: str) -> httpx.Response:
@@ -108,12 +109,12 @@ def account_mock():
     return router
 
 
-def get_account(region: Regions = None, metric: bool = True):
+def get_account(region: Optional[Regions] = None, metric: bool = True):
     """Returns account without token and vehicles (sync)."""
     return MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION, use_metric_units=metric)
 
 
-async def get_mocked_account(region: Regions = None, metric: bool = True):
+async def get_mocked_account(region: Optional[Regions] = None, metric: bool = True):
     """Returns pre-mocked account."""
     with account_mock():
         account = get_account(region, metric)

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -195,7 +195,7 @@ async def test_parse_f31_no_position(caplog):
     """Test parsing of F31 data with position tracking disabled in the vehicle."""
     status = (await get_mocked_account()).get_vehicle(VIN_F31).status
 
-    assert status.gps_position == (None, None)
+    assert status.gps_position is None
     assert status.gps_heading is None
 
     assert len(get_deprecation_warning_count(caplog)) == 2

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -54,9 +54,7 @@ def test_parse_datetime(caplog):
 
     assert dt_without_milliseconds == parse_datetime("2021-11-12T13:14:15Z")
 
-    if sys.version_info >= (3, 7):
-        # Don't test timezone parsing on Python 3.6 (not supported there)
-        assert dt_without_milliseconds == parse_datetime("2021-11-12T16:14:15+03:00")
+    assert dt_without_milliseconds == parse_datetime("2021-11-12T16:14:15+03:00")
 
     unparseable_datetime = "2021-14-12T13:14:15Z"
     assert parse_datetime(unparseable_datetime) is None
@@ -71,10 +69,8 @@ def test_parse_datetime(caplog):
 @pytest.mark.asyncio
 async def test_account_timezone():
     """Test the timezone in MyBMWAccount."""
-    # mocking the timezone doesn't work with the time_machine<2.7.1 on Python 3.6
-    if sys.version_info > (3, 7):
-        account = await get_mocked_account()
-        assert account.utcdiff == 960
+    account = await get_mocked_account()
+    assert account.utcdiff == 960
 
 
 def test_json_encoder():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for utils."""
 import datetime
 import json
-import sys
 
 try:
     import zoneinfo

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -280,7 +280,7 @@ async def test_parse_f31_no_position(caplog):
     """Test parsing of F31 data with position tracking disabled in the vehicle."""
     vehicle = (await get_mocked_account()).get_vehicle(VIN_F31)
 
-    assert vehicle.vehicle_location.location == (None, None)
+    assert vehicle.vehicle_location.location is None
     assert vehicle.vehicle_location.heading is None
 
     assert len(get_deprecation_warning_count(caplog)) == 0


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Python 3.6 dropped out of official support in December 2021, so we're removing it from our tests. The current version should still work in Python 3.6, however our automated tests won't find any regressions (and we won't fix them for Python 3.6).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Drop Python 3.6 tests in accordance to https://devguide.python.org/versions/
- Add support for Python 3.11

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #494 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
