### PR TITLE
Add horn to cli

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -46,7 +46,7 @@ def main_parser() -> argparse.ArgumentParser:
     flash_parser.add_argument("vin", help=TEXT_VIN)
     flash_parser.set_defaults(func=light_flash)
 
-    horn_parser = subparsers.add_parser("horn", description="Flash the vehicle lights.")
+    horn_parser = subparsers.add_parser("horn", description="Trigger the vehicle horn")
     _add_default_arguments(horn_parser)
     horn_parser.add_argument("vin", help=TEXT_VIN)
     horn_parser.set_defaults(func=horn)

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -46,6 +46,11 @@ def main_parser() -> argparse.ArgumentParser:
     flash_parser.add_argument("vin", help=TEXT_VIN)
     flash_parser.set_defaults(func=light_flash)
 
+    flash_parser = subparsers.add_parser("horn", description="Flash the vehicle lights.")
+    _add_default_arguments(flash_parser)
+    flash_parser.add_argument("vin", help=TEXT_VIN)
+    flash_parser.set_defaults(func=horn)
+
     finder_parser = subparsers.add_parser("vehiclefinder", description="Update the vehicle GPS location.")
     _add_default_arguments(finder_parser)
     finder_parser.add_argument("vin", help=TEXT_VIN)
@@ -170,6 +175,17 @@ async def light_flash(args) -> None:
     await account.get_vehicles()
     vehicle = get_vehicle_or_return(account, args.vin)
     status = await vehicle.remote_services.trigger_remote_light_flash()
+    print(status.state)
+
+
+async def horn(args) -> None:
+    """Trigger the vehicle to horn."""
+    account = MyBMWAccount(
+        args.username, args.password, get_region_from_name(args.region), use_metric_units=(not args.imperial)
+    )
+    await account.get_vehicles()
+    vehicle = get_vehicle_or_return(account, args.vin)
+    status = await vehicle.remote_services.trigger_remote_horn()
     print(status.state)
 
 

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -46,10 +46,10 @@ def main_parser() -> argparse.ArgumentParser:
     flash_parser.add_argument("vin", help=TEXT_VIN)
     flash_parser.set_defaults(func=light_flash)
 
-    flash_parser = subparsers.add_parser("horn", description="Flash the vehicle lights.")
-    _add_default_arguments(flash_parser)
-    flash_parser.add_argument("vin", help=TEXT_VIN)
-    flash_parser.set_defaults(func=horn)
+    horn_parser = subparsers.add_parser("horn", description="Flash the vehicle lights.")
+    _add_default_arguments(horn_parser)
+    horn_parser.add_argument("vin", help=TEXT_VIN)
+    horn_parser.set_defaults(func=horn)
 
     finder_parser = subparsers.add_parser("vehiclefinder", description="Update the vehicle GPS location.")
     _add_default_arguments(finder_parser)


### PR DESCRIPTION
## Proposed change
For convenience it would be nice to have the possibility of triggering the horn via cli. Same as it's possible to flash the lights via cli or app it should be possible to horn via cli or app.

I added the function to the cli.py file the same way the light flashing is implemented.


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
Regarding tests: I haven't seen api-tests so i did not add unit tests for this functionality. If you point me to some example tests I can add them, too.
