### PR TITLE
Add default value for `name` in sendpoi

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -15,6 +15,7 @@ import httpx
 from bimmer_connected.account import MyBMWAccount
 from bimmer_connected.api.client import MyBMWClient
 from bimmer_connected.api.regions import get_region_from_name, valid_regions
+from bimmer_connected.const import DEFAULT_POI_NAME
 from bimmer_connected.utils import MyBMWJSONEncoder, log_response_store_to_file
 from bimmer_connected.vehicle import MyBMWVehicle, VehicleViewDirection
 
@@ -67,7 +68,7 @@ def main_parser() -> argparse.ArgumentParser:
     sendpoi_parser.add_argument("vin", help=TEXT_VIN)
     sendpoi_parser.add_argument("latitude", help="Latitude of the POI", type=float)
     sendpoi_parser.add_argument("longitude", help="Longitude of the POI", type=float)
-    sendpoi_parser.add_argument("--name", help="(optional, display only) Name of the POI", nargs="?", default=None)
+    sendpoi_parser.add_argument("--name", help="Name of the POI", nargs="?", default=DEFAULT_POI_NAME)
     sendpoi_parser.add_argument(
         "--street", help="(optional, display only) Street & House No. of the POI", nargs="?", default=None
     )

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -83,3 +83,5 @@ SERVICE_CHARGING_PROFILE = "CHARGING_PROFILE"
 ATTR_STATE = "state"
 ATTR_CAPABILITIES = "capabilities"
 ATTR_ATTRIBUTES = "attributes"
+
+DEFAULT_POI_NAME = "Sent with ♥ by bimmer_connected"

--- a/bimmer_connected/models.py
+++ b/bimmer_connected/models.py
@@ -5,6 +5,8 @@ from dataclasses import InitVar, dataclass, field
 from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
+from bimmer_connected.const import DEFAULT_POI_NAME
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -104,7 +106,7 @@ class PointOfInterest:
 
     lat: InitVar[float]
     lon: InitVar[float]
-    name: Optional[str] = None
+    name: Optional[str] = DEFAULT_POI_NAME
     street: InitVar[str] = None
     postal_code: InitVar[str] = None
     city: InitVar[str] = None

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -19,6 +19,7 @@ import httpx
 import pytest
 import time_machine
 
+from bimmer_connected.models import PointOfInterest
 from bimmer_connected.vehicle import remote_services
 from bimmer_connected.vehicle.remote_services import ExecutionState, RemoteServiceStatus
 
@@ -244,3 +245,20 @@ async def test_poi():
 
     with pytest.raises(TypeError):
         await vehicle.remote_services.trigger_send_poi({"lat": 12.34})
+
+
+def test_poi_parsing():
+    """Test correct parsing of PointOfInterest."""
+
+    poi_data = PointOfInterest(**POI_DATA)
+
+    # Check parsing of attributes required by API
+    assert poi_data.coordinates.latitude == POI_DATA["lat"]
+    assert poi_data.coordinates.longitude == POI_DATA["lon"]
+    assert poi_data.name == POI_DATA["name"]
+
+    # Check that default attributes
+    poi_data = PointOfInterest(lat=POI_DATA["lat"], lon=POI_DATA["lon"])
+    assert poi_data.coordinates.latitude == POI_DATA["lat"]
+    assert poi_data.coordinates.longitude == POI_DATA["lon"]
+    assert poi_data.name == "Sent with ♥ by bimmer_connected"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enforces that the `name` entity is always filled when sending POI to the vehicle.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #512 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
