### PR TITLE
Update httpx error handler

### DIFF
--- a/bimmer_connected/models.py
+++ b/bimmer_connected/models.py
@@ -143,3 +143,11 @@ class ChargingSettings:
     isUnlockCableActive = None
     acLimitValue: Optional[int] = None
     dcLoudness = None
+
+
+class MyBMWAPIError(Exception):
+    """General BMW API error."""
+
+
+class MyBMWAuthError(MyBMWAPIError):
+    """Auth-related error from BMW API (HTTP status codes 401 and 403)."""

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,12 +1,12 @@
 """Tests for API that are not covered by other tests."""
 import json
 
-import httpx
 import pytest
 
 from bimmer_connected.account import MyBMWAccount
 from bimmer_connected.api.regions import get_region_from_name, valid_regions
 from bimmer_connected.api.utils import anonymize_data
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.utils import log_response_store_to_file
 
 from . import RESPONSE_DIR, TEST_PASSWORD, TEST_REGION, TEST_USERNAME, get_fingerprint_count, load_response
@@ -63,7 +63,7 @@ async def test_storing_fingerprints(tmp_path):
         mock_api.get("/eadrax-vcs/v4/vehicles/state").respond(
             500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
         )
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(MyBMWAPIError):
             await account.get_vehicles()
 
     log_response_store_to_file(account.get_stored_responses(), tmp_path)

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List
 
+from bimmer_connected.models import MyBMWAPIError
 from bimmer_connected.vehicle.charging_profile import ChargingMode
 
 try:
@@ -207,7 +208,7 @@ async def test_get_remote_service_status():
             ],
         )
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(MyBMWAPIError):
             await vehicle.remote_services._block_until_done(uuid4())
         with pytest.raises(ValueError):
             await vehicle.remote_services._block_until_done(uuid4())


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prompted by https://github.com/home-assistant/core/pull/90274, this PR introduces two new exceptions: `MyBMWAuthException` (HTTP status codes 401 and 403) and `MyBMWAPIException` (all other HTTP error codes).
These two are replacing all `httpx.HTTPStatusError` exceptions that might be raised (i.e. a request was technically successful but has a 4xx or 5xx HTTP status code).

The `request.raise_for_status()` handlers in `MyBMWClient`, `MyBMWLoginClient` and `MyBMWLoginRetry` have been adjusted accordingly to use `handle_httpstattuserror()`.

Most changes originate from `MyBMWAuthentication._login_row_na()` and  `MyBMWAuthentication._login_row_china()` as the `try ... except` block was removed (this is now handled directly in `MyBMWLoginClient`.

While this is a change deep at the base of our HTTP logic, it should not cause any issue. All tests pass after being converted from `httpx.HTTPStatusError` to the new exception classes.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
