### PR TITLE
Allow tire target pressure to be empty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.251
+    rev: v0.0.265
     hooks:
       - id: ruff
         args:
           - --fix
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
         args:
@@ -14,7 +14,7 @@ repos:
           - --quiet
         files: ^((bimmer_connected|test)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       - id: codespell
         args:
@@ -24,7 +24,7 @@ repos:
         exclude_types: [csv, json]
         exclude: ^test/responses/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.2.0
     hooks: 
       - id: mypy
         name: mypy

--- a/bimmer_connected/vehicle/tires.py
+++ b/bimmer_connected/vehicle/tires.py
@@ -13,7 +13,7 @@ class TireState:
 
     def __init__(self, status: Dict, details: Optional[Dict] = None):
         self.current_pressure: int = status["currentPressure"]
-        self.target_pressure: int = status["targetPressure"]
+        self.target_pressure: Optional[int] = status.get("targetPressure")
         self.season: Optional[int] = None
         self.manufacturing_week: Optional[datetime] = None
 

--- a/test/responses/G20/bmw-eadrax-vcs_v4_vehicles_state_WBA00000000DEMO03.json
+++ b/test/responses/G20/bmw-eadrax-vcs_v4_vehicles_state_WBA00000000DEMO03.json
@@ -199,7 +199,6 @@
                 "status": {
                     "currentPressure": 241,
                     "pressureStatus": 0,
-                    "targetPressure": 269,
                     "wearStatus": 0
                 }
             },
@@ -221,7 +220,6 @@
                 "status": {
                     "currentPressure": 255,
                     "pressureStatus": 0,
-                    "targetPressure": 269,
                     "wearStatus": 0
                 }
             },
@@ -243,7 +241,6 @@
                 "status": {
                     "currentPressure": 324,
                     "pressureStatus": 0,
-                    "targetPressure": 303,
                     "wearStatus": 0
                 }
             },
@@ -265,7 +262,6 @@
                 "status": {
                     "currentPressure": 331,
                     "pressureStatus": 0,
-                    "targetPressure": 303,
                     "wearStatus": 0
                 }
             }

--- a/test/test_vehicle_status.py
+++ b/test/test_vehicle_status.py
@@ -484,6 +484,13 @@ async def test_tires():
     assert tires.front_left.manufacturing_week is None
     assert tires.front_left.season is None
 
+    # Vehicle with current tire pressure and details, but no target pressure
+    tires = account.get_vehicle(VIN_G20).tires
+    assert tires.front_left.current_pressure == 241
+    assert tires.front_left.target_pressure is None
+    assert tires.front_left.manufacturing_week == datetime.datetime(2021, 10, 4, 0, 0)
+    assert tires.front_left.season == 2
+
     # Vehicle with details
     tires = account.get_vehicle(VIN_G70).tires
     assert tires.rear_left.current_pressure == 261


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As the API apparently has changed (or at least doesn't provide `targetPressure` on all cars), we now allow it to be null.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/92550
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
