### PR TITLE
Changes Regions.CHINA APP_VERSIONS to 3.1.0

### DIFF
--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -46,7 +46,7 @@ AES_KEYS = {
 APP_VERSIONS = {
     Regions.NORTH_AMERICA: "3.3.1(22418)",
     Regions.REST_OF_WORLD: "3.3.1(22418)",
-    Regions.CHINA: "3.3.1(22418)",
+    Regions.CHINA: "3.1.0(20658)",
 }
 
 HTTPX_TIMEOUT = 30.0


### PR DESCRIPTION
## Proposed change

Change the APP_VERSIONS Regions.CHINA to "3.1.0(20658)"


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Version 3.3.1(22418) cannot work under China's API, the interface will return a 422 error. This will break the normal functioning of the refresh token, and also disrupt the login process (if someone has customized the logic for generating the x-login-nonce).

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
