### PR TITLE
China login

### DIFF
--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -61,7 +61,7 @@ class MyBMWAuthentication(httpx.Auth):
         self.refresh_token: Optional[str] = refresh_token
         self.session_id: str = str(uuid4())
         self._lock: Optional[asyncio.Lock] = None
-        self.gcid: str = ""
+        self.gcid: Optional[str] = None
 
     @property
     def login_lock(self) -> asyncio.Lock:
@@ -345,6 +345,7 @@ class MyBMWAuthentication(httpx.Auth):
             "access_token": response_json["access_token"],
             "expires_at": expires_at,
             "refresh_token": response_json["refresh_token"],
+            "gcid": response_json["gcid"],
         }
 
 

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -11,11 +11,11 @@ from uuid import uuid4
 
 import httpx
 import jwt
-from Crypto.Cipher import AES, PKCS1_v1_5
+from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
-from Crypto.Util.Padding import pad
 
-from bimmer_connected.api.regions import Regions, get_aes_keys, get_app_version, get_ocp_apim_key, get_server_url
+
+from bimmer_connected.api.regions import Regions, get_app_version, get_ocp_apim_key, get_server_url
 from bimmer_connected.api.utils import (
     create_s256_code_challenge,
     generate_token,
@@ -45,13 +45,13 @@ class MyBMWAuthentication(httpx.Auth):
     """Authentication and Retry Handler for MyBMW API."""
 
     def __init__(
-            self,
-            username: str,
-            password: str,
-            region: Regions,
-            access_token: Optional[str] = None,
-            expires_at: Optional[datetime.datetime] = None,
-            refresh_token: Optional[str] = None,
+        self,
+        username: str,
+        password: str,
+        region: Regions,
+        access_token: Optional[str] = None,
+        expires_at: Optional[datetime.datetime] = None,
+        refresh_token: Optional[str] = None,
     ):
         self.username: str = username
         self.password: str = password

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -45,13 +45,13 @@ class MyBMWAuthentication(httpx.Auth):
     """Authentication and Retry Handler for MyBMW API."""
 
     def __init__(
-        self,
-        username: str,
-        password: str,
-        region: Regions,
-        access_token: Optional[str] = None,
-        expires_at: Optional[datetime.datetime] = None,
-        refresh_token: Optional[str] = None,
+            self,
+            username: str,
+            password: str,
+            region: Regions,
+            access_token: Optional[str] = None,
+            expires_at: Optional[datetime.datetime] = None,
+            refresh_token: Optional[str] = None,
     ):
         self.username: str = username
         self.password: str = password
@@ -290,7 +290,7 @@ class MyBMWAuthentication(httpx.Auth):
                     if captcha_check_res.json()["code"] == 200:
                         break
                 except Exception:
-                    pass
+                    continue
 
             # Get token
             response = await client.post(

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -287,9 +287,9 @@ class MyBMWAuthentication(httpx.Auth):
                         AUTH_CHINA_CAPTCHA_CHECK_URL,
                         json={"position": 0.74 + i / 100, "verifyId": verify_id},
                     )
-                    if captcha_check_res.status_code == 200:
+                    if captcha_check_res.status_code == 201:
                         break
-                except Exception:
+                except MyBMWAPIError:
                     continue
 
             # Get token

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -51,6 +51,7 @@ class MyBMWAuthentication(httpx.Auth):
         access_token: Optional[str] = None,
         expires_at: Optional[datetime.datetime] = None,
         refresh_token: Optional[str] = None,
+        gcid: Optional[str] = None,
     ):
         self.username: str = username
         self.password: str = password
@@ -60,7 +61,7 @@ class MyBMWAuthentication(httpx.Auth):
         self.refresh_token: Optional[str] = refresh_token
         self.session_id: str = str(uuid4())
         self._lock: Optional[asyncio.Lock] = None
-        self.gcid: Optional[str] = None
+        self.gcid: Optional[str] = gcid
 
     @property
     def login_lock(self) -> asyncio.Lock:
@@ -286,7 +287,7 @@ class MyBMWAuthentication(httpx.Auth):
                         AUTH_CHINA_CAPTCHA_CHECK_URL,
                         json={"position": 0.74 + i / 100, "verifyId": verify_id},
                     )
-                    if captcha_check_res.json()["code"] == 200:
+                    if captcha_check_res.status_code == 200:
                         break
                 except Exception:
                     continue

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -14,21 +14,20 @@ import jwt
 from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
 
-
 from bimmer_connected.api.regions import Regions, get_app_version, get_ocp_apim_key, get_server_url
 from bimmer_connected.api.utils import (
     create_s256_code_challenge,
+    generate_cn_nonce,
     generate_token,
     get_correlation_id,
     handle_httpstatuserror,
-    generate_cn_nonce
 )
 from bimmer_connected.const import (
+    AUTH_CHINA_CAPTCHA_CHECK_URL,
+    AUTH_CHINA_CAPTCHA_URL,
     AUTH_CHINA_LOGIN_URL,
     AUTH_CHINA_PUBLIC_KEY_URL,
     AUTH_CHINA_TOKEN_URL,
-    AUTH_CHINA_CAPTCHA_URL,
-    AUTH_CHINA_CAPTCHA_CHECK_URL,
     HTTPX_TIMEOUT,
     OAUTH_CONFIG_URL,
     USER_AGENT,
@@ -300,7 +299,7 @@ class MyBMWAuthentication(httpx.Auth):
                     "mobile": self.username,
                     "password": pw_encrypted,
                     "verifyId": verify_id,
-                    "deviceId": self.username
+                    "deviceId": self.username,
                 },
             )
             response_json = response.json()["data"]

--- a/bimmer_connected/api/regions.py
+++ b/bimmer_connected/api/regions.py
@@ -2,7 +2,7 @@
 from base64 import b64decode
 from typing import Dict, List
 
-from bimmer_connected.const import AES_KEYS, APP_VERSIONS, OCP_APIM_KEYS, SERVER_URLS_MYBMW, Regions
+from bimmer_connected.const import APP_VERSIONS, OCP_APIM_KEYS, SERVER_URLS_MYBMW, Regions
 
 
 def valid_regions() -> List[str]:
@@ -34,8 +34,3 @@ def get_app_version(region: Regions) -> str:
 def get_ocp_apim_key(region: Regions) -> str:
     """Get the authorization for OAuth settings."""
     return b64decode(OCP_APIM_KEYS[region]).decode()
-
-
-def get_aes_keys(region: Regions) -> Dict[str, bytes]:
-    """Get the keys for login nonce."""
-    return {k: b64decode(v) for k, v in AES_KEYS[region].items()}

--- a/bimmer_connected/api/regions.py
+++ b/bimmer_connected/api/regions.py
@@ -1,6 +1,6 @@
 """Get the right url for the different countries."""
 from base64 import b64decode
-from typing import Dict, List
+from typing import List
 
 from bimmer_connected.const import APP_VERSIONS, OCP_APIM_KEYS, SERVER_URLS_MYBMW, Regions
 

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -1,6 +1,7 @@
 """Utils for bimmer_connected.api."""
 
 import base64
+import datetime
 import hashlib
 import json
 import logging
@@ -8,14 +9,13 @@ import mimetypes
 import random
 import re
 import string
-import datetime
 from typing import Dict, List, Optional, Union
 from uuid import uuid4
-from Crypto.Hash import SHA256
-from Crypto.Cipher import AES
-from Crypto.Util.Padding import pad
 
 import httpx
+from Crypto.Cipher import AES
+from Crypto.Hash import SHA256
+from Crypto.Util.Padding import pad
 
 from bimmer_connected.models import AnonymizedResponse, MyBMWAPIError, MyBMWAuthError
 
@@ -143,11 +143,13 @@ def anonymize_response(response: httpx.Response) -> AnonymizedResponse:
     return AnonymizedResponse(f"{brand}{url_path}{file_extension}", content)
 
 
-def generate_random_base64_string(size):
+def generate_random_base64_string(size: int) -> str:
+    """Generate a random base64 string with size."""
     return base64.b64encode(bytes(random.randint(0, 255) for _ in range(size))).decode()[:size]
 
 
-def generate_cn_nonce(username):
+def generate_cn_nonce(username: str) -> str:
+    """Generate a x-login-nonce string."""
     key = generate_random_base64_string(16)
     iv = generate_random_base64_string(16)
 

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -47,10 +47,10 @@ def get_correlation_id() -> Dict[str, str]:
 
 
 async def handle_httpstatuserror(
-        ex: httpx.HTTPStatusError,
-        module: str = "API",
-        log_handler: Optional[logging.Logger] = None,
-        dont_raise: bool = False,
+    ex: httpx.HTTPStatusError,
+    module: str = "API",
+    log_handler: Optional[logging.Logger] = None,
+    dont_raise: bool = False,
 ) -> None:
     """Try to extract information from response and re-raise Exception."""
     _logger = log_handler or logging.getLogger(__name__)
@@ -117,7 +117,7 @@ def anonymize_vin(match: re.Match):
     """Anonymize VINs but keep assignment."""
     vin = match.groupdict()["vin"]
     if vin not in ANONYMIZED_VINS:
-        ANONYMIZED_VINS[vin] = f"{vin[:3]}0FINGERPRINT{str(len(ANONYMIZED_VINS) + 1).zfill(2)}"
+        ANONYMIZED_VINS[vin] = f"{vin[:3]}0FINGERPRINT{str(len(ANONYMIZED_VINS)+1).zfill(2)}"
     return ANONYMIZED_VINS[vin]
 
 

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -58,6 +58,8 @@ X_USER_AGENT = "android(TQ2A.230405.003.B2);{brand};{app_version};{region}"
 AUTH_CHINA_PUBLIC_KEY_URL = "/eadrax-coas/v1/cop/publickey"
 AUTH_CHINA_LOGIN_URL = "/eadrax-coas/v2/login/pwd"
 AUTH_CHINA_TOKEN_URL = "/eadrax-coas/v2/oauth/token"
+AUTH_CHINA_CAPTCHA_URL = "/eadrax-coas/v2/cop/slider-captcha"
+AUTH_CHINA_CAPTCHA_CHECK_URL = "/eadrax-coas/v1/cop/check-captcha"
 
 OAUTH_CONFIG_URL = "/eadrax-ucs/v1/presentation/oauth/config"
 

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -36,13 +36,6 @@ OCP_APIM_KEYS = {
     Regions.REST_OF_WORLD: "NGYxYzg1YTMtNzU4Zi1hMzdkLWJiYjYtZjg3MDQ0OTRhY2Zh",
 }
 
-AES_KEYS = {
-    Regions.CHINA: {
-        "key": "UzJUdzEwdlExWGYySmxLYQ==",
-        "iv": "dTFGUDd4ZWRrQWhMR3ozVQ==",
-    }
-}
-
 APP_VERSIONS = {
     Regions.NORTH_AMERICA: "3.3.1(22418)",
     Regions.REST_OF_WORLD: "3.3.1(22418)",

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -46,7 +46,7 @@ AES_KEYS = {
 APP_VERSIONS = {
     Regions.NORTH_AMERICA: "3.3.1(22418)",
     Regions.REST_OF_WORLD: "3.3.1(22418)",
-    Regions.CHINA: "3.3.1(22418)",
+    Regions.CHINA: "3.1.0(20658)",
 }
 
 HTTPX_TIMEOUT = 30.0

--- a/test/responses/auth/auth_cn_login_pwd.json
+++ b/test/responses/auth/auth_cn_login_pwd.json
@@ -4,7 +4,8 @@
         "token_type": "Bearer",
         "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJEVU1NWSQxJFIkMTYzNzcwNTc5NTA3NSIsIm5iZiI6MTYzNzcwNTc5NSwiZXhwIjoxNjQ1NDgwODk1LCJpYXQiOjE2Mzc3MDU3OTV9.dGVpbpfrJOo895jiU6Rk16ESYz80klfJbIX9M4KD1hQ",
         "usid": "DUMMY",
-        "cid": "DUMMY"
+        "cid": "DUMMY",
+        "gcid": "DUMMY"
     },
     "code": 200,
     "error": false,

--- a/test/responses/auth/auth_slider_captcha.json
+++ b/test/responses/auth/auth_slider_captcha.json
@@ -1,0 +1,10 @@
+{
+  "description": "ok",
+  "code": 200,
+  "error": false,
+  "data": {
+    "verifyId": "f40f54f1cb40463ba7188bd73e906d33",
+    "backGroundImg": "/xxxx",
+    "cutImg": "xxxx"
+  }
+}

--- a/test/responses/auth/auth_slider_captcha_check.json
+++ b/test/responses/auth/auth_slider_captcha_check.json
@@ -1,0 +1,6 @@
+{
+  "description": "ok",
+  "code": 200,
+  "error": false,
+  "data": null
+}

--- a/test/responses/auth/auth_token.json
+++ b/test/responses/auth/auth_token.json
@@ -3,5 +3,7 @@
     "token_type": "Bearer",
     "expires_in": 28799,
     "refresh_token": "another_token_string",
-    "scope": "authenticate_user vehicle_data remote_services"
+    "scope": "authenticate_user vehicle_data remote_services",
+    "usid": "DUMMY",
+    "gcid": "DUMMY"
 }

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -110,9 +110,14 @@ def account_mock():
     router.post("/eadrax-coas/v2/cop/slider-captcha").respond(
         200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha.json")
     )
-    router.post("/eadrax-coas/v1/cop/check-captcha").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")
+
+    router.post("/eadrax-coas/v1/cop/check-captcha").mock(
+        side_effect=[
+            httpx.Response(422),
+            httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")),
+        ]
     )
+
     router.post("/eadrax-coas/v2/login/pwd").respond(
         200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_pwd.json")
     )
@@ -348,7 +353,6 @@ async def test_invalid_password_china():
         mock_api.post("/eadrax-coas/v2/login/pwd").respond(
             422, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_error.json")
         )
-        mock_api.post("/eadrax-coas/v1/cop/check-captcha").respond(422)
         with pytest.raises(MyBMWAPIError):
             account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
             await account.get_vehicles()

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -348,6 +348,7 @@ async def test_invalid_password_china():
         mock_api.post("/eadrax-coas/v2/login/pwd").respond(
             422, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_error.json")
         )
+        mock_api.post("/eadrax-coas/v1/cop/check-captcha").respond(422)
         with pytest.raises(MyBMWAPIError):
             account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
             await account.get_vehicles()

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -114,7 +114,7 @@ def account_mock():
     router.post("/eadrax-coas/v1/cop/check-captcha").mock(
         side_effect=[
             httpx.Response(422),
-            httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")),
+            httpx.Response(201, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")),
         ]
     )
 

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -107,6 +107,12 @@ def account_mock():
     router.get("/eadrax-coas/v1/cop/publickey").respond(
         200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_publickey.json")
     )
+    router.post("/eadrax-coas/v2/cop/slider-captcha").respond(
+        200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha.json")
+    )
+    router.post("/eadrax-coas/v1/cop/check-captcha").respond(
+        200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")
+    )
     router.post("/eadrax-coas/v2/login/pwd").respond(
         200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_pwd.json")
     )


### PR DESCRIPTION
## Proposed change

Add a new nonce algorithm for the China region login, automatically complete the login graphic verification code, restore the login function for the China region, and update the refresh token method.


## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Due to the public disclosure of the x-login-nonce algorithm in the Chinese region, the logic has been added to the library. Currently, password login requires a graphical captcha.

The solution we have incorporated allows for automatic bypassing of the graphical captcha obtained from https://gitee.com/cvnc/BMW/blob/master/lib/BMWLogin.js

The refresh token also needs to be included in the header with the x-login-nonce encoded using `gcid`.

![image](https://github.com/bimmerconnected/bimmer_connected/assets/1411722/ecac5f0d-d0af-4d68-b86a-1b5d36dd2377)



- This PR fixes or closes issue: fixes #504
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
