### PR TITLE
Change is_vehicle_active to deprecated

### DIFF
--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -213,6 +213,7 @@ class MyBMWVehicle:
         return self.data[ATTR_CAPABILITIES].get("vehicleFinder", False)
 
     @property
+    @deprecated()
     def is_vehicle_active(self) -> bool:
         """Check if the vehicle is active/moving.
 

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -213,9 +213,8 @@ class MyBMWVehicle:
         return self.data[ATTR_CAPABILITIES].get("vehicleFinder", False)
 
     @property
-    @deprecated()
     def is_vehicle_active(self) -> bool:
-        """Deprecated, always returns False
+        """Deprecated, always returns False.
         
         Check if the vehicle is active/moving.
 

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -215,7 +215,9 @@ class MyBMWVehicle:
     @property
     @deprecated()
     def is_vehicle_active(self) -> bool:
-        """Check if the vehicle is active/moving.
+        """Deprecated, always returns False
+        
+        Check if the vehicle is active/moving.
 
         If the vehicle was active/moving at the time of the last status update, current position is not available.
         """

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -215,7 +215,7 @@ class MyBMWVehicle:
     @property
     def is_vehicle_active(self) -> bool:
         """Deprecated, always returns False.
-        
+
         Check if the vehicle is active/moving.
 
         If the vehicle was active/moving at the time of the last status update, current position is not available.


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mark `vehicle.is_vehicle_active` as deprecated to avoid confusion, as it no longer returns the inMotion status, as well as explain in docs it always returns False. Users might not notice that this function always returns False.

However, if you are working on bringing this functionality back, feel free to close this PR.


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/bimmerconnected/bimmer_connected/issues/523

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
