### PR TITLE
Handle quota exceeded in HTTP 403

### DIFF
--- a/bimmer_connected/models.py
+++ b/bimmer_connected/models.py
@@ -153,5 +153,9 @@ class MyBMWAuthError(MyBMWAPIError):
     """Auth-related error from BMW API (HTTP status codes 401 and 403)."""
 
 
+class MyBMWQuotaError(MyBMWAPIError):
+    """Quota exceeded on BMW API."""
+
+
 class MyBMWRemoteServiceError(MyBMWAPIError):
     """Error when executing remote services."""

--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -9,7 +9,7 @@ import pathlib
 import time
 import traceback
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from bimmer_connected.models import AnonymizedResponse
 
@@ -62,7 +62,7 @@ def parse_datetime(date_str: str) -> Optional[datetime.datetime]:
 class MyBMWJSONEncoder(json.JSONEncoder):
     """JSON Encoder that handles data classes, properties and additional data types."""
 
-    def default(self, o):  # noqa: D102
+    def default(self, o) -> Union[str, dict]:  # noqa: D102
         if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
             return o.isoformat()
         if not isinstance(o, Enum) and hasattr(o, "__dict__") and isinstance(o.__dict__, Dict):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates our API client to handle not directly resolvable quota issues with a new exception (`MyBMWQuotaError`).
Additional logic was needed, as sometimes this error not only occurs with HTTP status code 429, but also 403 Forbidden.

After this is merged, we can update the HA component to not require re-entering the password on quota issues (see 

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/85962

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
