### PR TITLE
Add required fields for sendpoi

### DIFF
--- a/bimmer_connected/models.py
+++ b/bimmer_connected/models.py
@@ -97,6 +97,17 @@ class PointOfInterestAddress:
     city: Optional[str] = None
     country: Optional[str] = None
 
+    # The following attributes are not by us but available in the API
+    banchi: Optional[str] = None
+    chome: Optional[str] = None
+    countryCode: Optional[str] = None
+    district: Optional[str] = None
+    go: Optional[str] = None
+    houseNumber: Optional[str] = None
+    region: Optional[str] = None
+    regionCode: Optional[str] = None
+    settlement: Optional[str] = None
+
 
 @dataclass
 class PointOfInterest:
@@ -112,12 +123,28 @@ class PointOfInterest:
 
     coordinates: GPSPosition = field(init=False)
     locationAddress: Optional[PointOfInterestAddress] = field(init=False)
+    # The following attributes are not by us but required in the API
+    formattedAddress: Optional[str] = None
     entryPoints: List = field(init=False, default_factory=list)
+
+    # The following attributes are not by us but available in the API
+    address: Optional[str] = None
+    baseCategoryId: Optional[str] = None
+    phoneNumber: Optional[str] = None
+    provider: Optional[str] = None
+    providerId: Optional[str] = None
+    providerPoiId: str = ""
+    sourceType: Optional[str] = None
+    type: Optional[str] = None
+    vehicleCategoryId: Optional[str] = None
 
     def __post_init__(self, lat, lon, street, postal_code, city, country):
         self.coordinates = GPSPosition(lat, lon)
 
         self.locationAddress = PointOfInterestAddress(street, postal_code, city, country)
+
+        if not self.formattedAddress:
+            self.formattedAddress = ", ".join([i for i in [street, postal_code, city] if i]) or "Coordinates only"
 
 
 class ValueWithUnit(NamedTuple):

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -427,9 +427,11 @@ def test_poi_parsing():
     assert poi_data.coordinates.latitude == POI_DATA["lat"]
     assert poi_data.coordinates.longitude == POI_DATA["lon"]
     assert poi_data.name == POI_DATA["name"]
+    assert poi_data.formattedAddress == f"{POI_DATA['street']}, {POI_DATA['postal_code']}, {POI_DATA['city']}"
 
-    # Check that default attributes
+    # Check the default attributes
     poi_data = PointOfInterest(lat=POI_DATA["lat"], lon=POI_DATA["lon"])
     assert poi_data.coordinates.latitude == POI_DATA["lat"]
     assert poi_data.coordinates.longitude == POI_DATA["lon"]
     assert poi_data.name == "Sent with ♥ by bimmer_connected"
+    assert poi_data.formattedAddress == "Coordinates only"

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -435,3 +435,10 @@ def test_poi_parsing():
     assert poi_data.coordinates.longitude == POI_DATA["lon"]
     assert poi_data.name == "Sent with ♥ by bimmer_connected"
     assert poi_data.formattedAddress == "Coordinates only"
+
+    # Check the default attributes with formatted address
+    poi_data = PointOfInterest(lat=POI_DATA["lat"], lon=POI_DATA["lon"], formattedAddress="Somewhere over rainbow")
+    assert poi_data.coordinates.latitude == POI_DATA["lat"]
+    assert poi_data.coordinates.longitude == POI_DATA["lon"]
+    assert poi_data.name == "Sent with ♥ by bimmer_connected"
+    assert poi_data.formattedAddress == "Somewhere over rainbow"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Send all the entries to the MyBMW API when calling `send-to-car`. Especially important is the `formattedAddress` which if not given or an empty string will cause the API to respond with HTTP 500 error.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
