### PR TITLE
Refactor tests to conftest, add stateful tests for remote services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.265
+    rev: v0.0.282
     hooks:
       - id: ruff
         args:
           - --fix
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         args:
@@ -14,7 +14,7 @@ repos:
           - --quiet
         files: ^((bimmer_connected|test)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
       - id: codespell
         args:
@@ -24,7 +24,7 @@ repos:
         exclude_types: [csv, json]
         exclude: ^test/responses/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.4.1
     hooks: 
       - id: mypy
         name: mypy

--- a/bimmer_connected/vehicle/remote_services.py
+++ b/bimmer_connected/vehicle/remote_services.py
@@ -275,7 +275,7 @@ class RemoteServices:
                 charging_mode
             ].value
 
-        if precondition_climate:
+        if precondition_climate is not None:
             target_charging_profile["isPreconditionForDepartureActive"] = precondition_climate
 
         return await self.trigger_remote_service(

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -23,14 +23,21 @@ VIN_I01_NOREX = "WBY000000NOREXI01"
 VIN_I01_REX = "WBY00000000REXI01"
 VIN_I20 = "WBA00000000DEMO01"
 
-ALL_FINGERPRINTS: Dict[str, List[Dict]] = {brand.value: [] for brand in CarBrands}
+ALL_VEHICLES: Dict[str, List[Dict]] = {brand.value: [] for brand in CarBrands}
 ALL_STATES: Dict[str, Dict] = {}
 ALL_CHARGING_SETTINGS: Dict[str, Dict] = {}
+
+REMOTE_SERVICE_RESPONSE_INITIATED = RESPONSE_DIR / "remote_services" / "eadrax_service_initiated.json"
+REMOTE_SERVICE_RESPONSE_PENDING = RESPONSE_DIR / "remote_services" / "eadrax_service_pending.json"
+REMOTE_SERVICE_RESPONSE_DELIVERED = RESPONSE_DIR / "remote_services" / "eadrax_service_delivered.json"
+REMOTE_SERVICE_RESPONSE_EXECUTED = RESPONSE_DIR / "remote_services" / "eadrax_service_executed.json"
+REMOTE_SERVICE_RESPONSE_ERROR = RESPONSE_DIR / "remote_services" / "eadrax_service_error.json"
+REMOTE_SERVICE_RESPONSE_EVENTPOSITION = RESPONSE_DIR / "remote_services" / "eadrax_service_eventposition.json"
 
 
 def get_fingerprint_count() -> int:
     """Return number of loaded vehicles."""
-    return sum([len(vehicles) for vehicles in ALL_FINGERPRINTS.values()])
+    return sum([len(vehicles) for vehicles in ALL_VEHICLES.values()])
 
 
 def load_response(path: Union[Path, str]) -> Any:
@@ -44,7 +51,7 @@ def load_response(path: Union[Path, str]) -> Any:
 for fingerprint in RESPONSE_DIR.rglob("*-eadrax-vcs_v4_vehicles.json"):
     brand = fingerprint.stem.split("-")[0]
     for vehicle in load_response(fingerprint):
-        ALL_FINGERPRINTS[brand].append(vehicle)
+        ALL_VEHICLES[brand].append(vehicle)
 
 for state in RESPONSE_DIR.rglob("*-eadrax-vcs_v4_vehicles_state_*.json"):
     ALL_STATES[state.stem.split("_")[-1]] = load_response(state)

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,313 @@
+"""Fixtures for BMW tests."""
+
+import json
+from collections import defaultdict
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from bimmer_connected.vehicle.climate import ClimateActivityState
+from bimmer_connected.vehicle.fuel_and_battery import ChargingState
+
+try:
+    from unittest import mock
+
+    if not hasattr(mock, "AsyncMock"):
+        # AsyncMock was only introduced with Python3.8, so we have to use the backported module
+        raise ImportError()
+except ImportError:
+    import mock  # type: ignore[import,no-redef]  # noqa: UP026
+
+import httpx
+import respx
+
+from bimmer_connected.const import Regions
+from bimmer_connected.models import ChargingSettings
+from bimmer_connected.vehicle.remote_services import MAP_CHARGING_MODE_TO_REMOTE_SERVICE
+
+from . import (
+    ALL_VEHICLES,
+    REMOTE_SERVICE_RESPONSE_DELIVERED,
+    REMOTE_SERVICE_RESPONSE_EVENTPOSITION,
+    REMOTE_SERVICE_RESPONSE_EXECUTED,
+    REMOTE_SERVICE_RESPONSE_INITIATED,
+    REMOTE_SERVICE_RESPONSE_PENDING,
+    RESPONSE_DIR,
+    load_response,
+)
+
+POI_DATA = {
+    "lat": 37.4028943,
+    "lon": -121.9700289,
+    "name": "49ers",
+    "street": "4949 Marie P DeBartolo Way",
+    "city": "Santa Clara",
+    "postal_code": "CA 95054",
+    "country": "United States",
+}
+
+CHARGING_SETTINGS = {"target_soc": 75, "ac_limit": 16}
+
+STATUSREMOTE_SERVICE_RESPONSE_ORDER = [
+    REMOTE_SERVICE_RESPONSE_PENDING,
+    REMOTE_SERVICE_RESPONSE_DELIVERED,
+    REMOTE_SERVICE_RESPONSE_EXECUTED,
+]
+STATUSREMOTE_SERVICE_RESPONSE_DICT: Dict[str, List[Path]] = defaultdict(
+    lambda: deepcopy(STATUSREMOTE_SERVICE_RESPONSE_ORDER)
+)
+
+MAP_REMOTE_SERVICE_CHARGING_MODE_TO_STATE = {v: k.value for k, v in MAP_CHARGING_MODE_TO_REMOTE_SERVICE.items()}
+
+LOCAL_STATES: Dict[str, Dict] = {}
+LOCAL_CHARGING_SETTINGS: Dict[str, Dict] = {}
+
+
+class MyBMWMockRouter(respx.MockRouter):
+    """Stateful MockRouter for MyBMW APIs."""
+
+    def __init__(
+        self,
+        vehicles_to_load: Optional[List[str]] = None,
+        states: Optional[Dict[str, Dict]] = None,
+        charging_settings: Optional[Dict[str, Dict]] = None,
+    ) -> None:
+        """Initialize the MyBMWMockRouter with clean responses."""
+        super().__init__(assert_all_called=False)
+        self.vehicles_to_load = vehicles_to_load or []
+        self.states = deepcopy(states) if states else {}
+        self.charging_settings = deepcopy(charging_settings) if charging_settings else {}
+
+        self.add_login_routes()
+        self.add_vehicle_routes()
+        self.add_remote_service_routes()
+
+    # # # # # # # # # # # # # # # # # # # # # # # #
+    # Routes
+    # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def add_login_routes(self) -> None:
+        """Add routes for login."""
+
+        # Login to north_america and rest_of_world
+        self.get("/eadrax-ucs/v1/presentation/oauth/config").respond(
+            200, json=load_response(RESPONSE_DIR / "auth" / "oauth_config.json")
+        )
+        self.post("/gcdm/oauth/authenticate").mock(side_effect=self.authenticate_sideeffect)
+        self.post("/gcdm/oauth/token").respond(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json"))
+
+        # Login to china
+        self.get("/eadrax-coas/v1/cop/publickey").respond(
+            200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_publickey.json")
+        )
+        self.post("/eadrax-coas/v2/cop/slider-captcha").respond(
+            200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha.json")
+        )
+
+        self.post("/eadrax-coas/v1/cop/check-captcha").mock(
+            side_effect=[
+                httpx.Response(422),
+                httpx.Response(201, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")),
+            ]
+        )
+
+        self.post("/eadrax-coas/v2/login/pwd").respond(
+            200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_pwd.json")
+        )
+        self.post("/eadrax-coas/v2/oauth/token").respond(
+            200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")
+        )
+
+    def add_vehicle_routes(self) -> None:
+        """Add routes for vehicle requests."""
+
+        self.get("/eadrax-vcs/v4/vehicles").mock(side_effect=self.vehicles_sideeffect)
+        self.get("/eadrax-vcs/v4/vehicles/state").mock(side_effect=self.vehicle_state_sideeffect)
+        self.get("/eadrax-crccs/v2/vehicles").mock(side_effect=self.vehicle_charging_settings_sideeffect)
+
+    def add_remote_service_routes(self) -> None:
+        """Add routes for remote services."""
+
+        self.post(path__regex=r"/eadrax-vrccs/v3/presentation/remote-commands/(?P<vin>.+)/(?P<service>.+)$").mock(
+            side_effect=self.service_trigger_sideeffect
+        )
+        self.post(path__regex=r"/eadrax-crccs/v1/vehicles/(?P<vin>.+)/(?P<service>(start|stop)-charging)$").mock(
+            side_effect=self.service_trigger_sideeffect
+        )
+        self.post(path__regex=r"/eadrax-crccs/v1/vehicles/(?P<vin>.+)/charging-settings$").mock(
+            side_effect=self.charging_settings_sideeffect
+        )
+        self.post(path__regex=r"/eadrax-crccs/v1/vehicles/(?P<vin>.+)/charging-profile$").mock(
+            side_effect=self.charging_profile_sideeffect
+        )
+        self.post("/eadrax-vrccs/v3/presentation/remote-commands/eventStatus", params={"eventId": mock.ANY}).mock(
+            side_effect=self.service_status_sideeffect
+        )
+
+        self.post("/eadrax-dcs/v1/send-to-car/send-to-car").mock(side_effect=self.poi_sideeffect)
+        self.post("/eadrax-vrccs/v3/presentation/remote-commands/eventPosition", params={"eventId": mock.ANY}).respond(
+            200,
+            json=load_response(REMOTE_SERVICE_RESPONSE_EVENTPOSITION),
+        )
+
+    # # # # # # # # # # # # # # # # # # # # # # # #
+    # Authentication sideeffects
+    # # # # # # # # # # # # # # # # # # # # # # # #
+
+    @staticmethod
+    def authenticate_sideeffect(request: httpx.Request) -> httpx.Response:
+        """Return /oauth/authentication response based on request."""
+        request_text = request.read().decode("UTF-8")
+        if "username" in request_text and "password" in request_text and "grant_type" in request_text:
+            return httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "authorization_response.json"))
+        return httpx.Response(
+            302,
+            headers={
+                "Location": "com.mini.connected://oauth?code=CODE&state=STATE&client_id=CLIENT_ID&nonce=login_nonce",
+            },
+        )
+
+    # # # # # # # # # # # # # # # # # # # # # # # #
+    # Vehicle state sideeffects
+    # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def vehicles_sideeffect(self, request: httpx.Request) -> httpx.Response:
+        """Return /vehicles response based on x-user-agent."""
+        x_user_agent = request.headers.get("x-user-agent", "").split(";")
+        if len(x_user_agent) == 4:
+            brand = x_user_agent[1]
+        else:
+            raise ValueError("x-user-agent not configured correctly!")
+
+        # Test if given region is valid
+        _ = Regions(x_user_agent[3])
+
+        fingerprints = ALL_VEHICLES.get(brand, [])
+        if self.vehicles_to_load:
+            fingerprints = [f for f in fingerprints if f["vin"] in self.vehicles_to_load]
+
+        return httpx.Response(200, json=fingerprints)
+
+    def vehicle_state_sideeffect(self, request: httpx.Request) -> httpx.Response:
+        """Return /vehicles response based on x-user-agent."""
+        x_user_agent = request.headers.get("x-user-agent", "").split(";")
+        assert len(x_user_agent) == 4
+
+        try:
+            return httpx.Response(200, json=self.states[request.headers["bmw-vin"]])
+        except KeyError:
+            return httpx.Response(404)
+
+    def vehicle_charging_settings_sideeffect(self, request: httpx.Request) -> httpx.Response:
+        """Return /vehicles response based on x-user-agent."""
+        x_user_agent = request.headers.get("x-user-agent", "").split(";")
+        assert len(x_user_agent) == 4
+        assert "fields" in request.url.params
+        assert "has_charging_settings_capabilities" in request.url.params
+
+        try:
+            return httpx.Response(200, json=self.charging_settings[request.headers["bmw-vin"]])
+        except KeyError:
+            return httpx.Response(404)
+
+    # # # # # # # # # # # # # # # # # # # # # # # #
+    # Remote service sideeffects
+    # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def service_trigger_sideeffect(
+        self, request: httpx.Request, vin: str, service: Optional[str] = None
+    ) -> httpx.Response:
+        """Return specific eventId for each remote function."""
+
+        if service in ["door-lock", "door-unlock"]:
+            new_state = "LOCKED" if service == "door-lock" else "UNLOCKED"
+            self.states[vin]["state"]["doorsState"]["combinedSecurityState"] = new_state
+
+        elif service in ["climate-now"]:
+            new_state = (
+                ClimateActivityState.COOLING
+                if request.url.params["action"] == "START"
+                else ClimateActivityState.STANDBY
+            )
+            self.states[vin]["state"]["climateControlState"]["activity"] = new_state
+
+        elif service in ["start-charging", "stop-charging"]:
+            new_state = ChargingState.PLUGGED_IN if "stop" in service else ChargingState.CHARGING
+            self.states[vin]["state"]["electricChargingState"]["chargingStatus"] = new_state
+
+        json_data = load_response(REMOTE_SERVICE_RESPONSE_INITIATED)
+        json_data["eventId"] = str(uuid4())
+
+        return httpx.Response(200, json=json_data)
+
+    def charging_settings_sideeffect(self, request: httpx.Request, vin: str) -> httpx.Response:
+        """Check if payload is a valid charging settings payload and return evendId."""
+        cs = ChargingSettings(**json.loads(request.content))
+        self.states[vin]["state"]["electricChargingState"]["chargingTarget"] = cs.chargingTarget
+        self.states[vin]["state"]["chargingProfile"]["chargingSettings"]["acCurrentLimit"] = cs.acLimitValue
+
+        return self.service_trigger_sideeffect(request, vin)
+
+    def charging_profile_sideeffect(self, request: httpx.Request, vin: str) -> httpx.Response:
+        """Check if payload is a valid charging settings payload and return evendId."""
+
+        data = json.loads(request.content)
+
+        if {"chargingMode", "departureTimer", "isPreconditionForDepartureActive", "servicePack"} != set(data):
+            return httpx.Response(500)
+        if (
+            data["chargingMode"]["chargingPreference"] == "NO_PRESELECTION"
+            and data["chargingMode"]["type"] != "CHARGING_IMMEDIATELY"
+        ):
+            return httpx.Response(500)
+        if (
+            data["chargingMode"]["chargingPreference"] == "CHARGING_WINDOW"
+            and data["chargingMode"]["type"] != "TIME_SLOT"
+        ):
+            return httpx.Response(500)
+
+        if not isinstance(data["isPreconditionForDepartureActive"], bool):
+            return httpx.Response(500)
+
+        # separate charging profile endpoint
+        self.charging_settings[vin]["chargeAndClimateTimerDetail"]["chargingMode"]["chargingPreference"] = data[
+            "chargingMode"
+        ]["chargingPreference"]
+        self.charging_settings[vin]["chargeAndClimateTimerDetail"]["chargingMode"]["type"] = data["chargingMode"][
+            "type"
+        ]
+        self.charging_settings[vin]["chargeAndClimateTimerDetail"]["isPreconditionForDepartureActive"] = data[
+            "isPreconditionForDepartureActive"
+        ]
+
+        # state endpoint
+        self.states[vin]["state"]["chargingProfile"]["chargingPreference"] = data["chargingMode"]["chargingPreference"]
+        self.states[vin]["state"]["chargingProfile"]["chargingMode"] = MAP_REMOTE_SERVICE_CHARGING_MODE_TO_STATE[
+            data["chargingMode"]["type"]
+        ]
+        self.states[vin]["state"]["chargingProfile"]["climatisationOn"] = data["isPreconditionForDepartureActive"]
+
+        return self.service_trigger_sideeffect(request, vin)
+
+    @staticmethod
+    def service_status_sideeffect(request: httpx.Request) -> httpx.Response:
+        """Return all 3 eventStatus responses per function."""
+        response_data = STATUSREMOTE_SERVICE_RESPONSE_DICT[request.url.params["eventId"]].pop(0)
+        return httpx.Response(200, json=load_response(response_data))
+
+    @staticmethod
+    def poi_sideeffect(request: httpx.Request) -> httpx.Response:
+        """Check if payload is a valid POI."""
+        data = json.loads(request.content)
+        tests = all(
+            [
+                len(data["vin"]) == 17,
+                isinstance(data["location"]["coordinates"]["latitude"], float),
+                isinstance(data["location"]["coordinates"]["longitude"], float),
+                len(data["location"]["name"]) > 0,
+            ]
+        )
+        if not tests:
+            return httpx.Response(400)
+        return httpx.Response(201)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,47 @@
+"""Fixtures for BMW tests."""
+from typing import Optional
+
+try:
+    from unittest import mock
+
+    if not hasattr(mock, "AsyncMock"):
+        # AsyncMock was only introduced with Python3.8, so we have to use the backported module
+        raise ImportError()
+except ImportError:
+    import mock  # type: ignore[import,no-redef]  # noqa: UP026
+
+import pytest
+import respx
+
+from bimmer_connected.account import MyBMWAccount
+from bimmer_connected.const import Regions
+
+from . import (
+    ALL_CHARGING_SETTINGS,
+    ALL_STATES,
+    TEST_PASSWORD,
+    TEST_REGION,
+    TEST_USERNAME,
+)
+from .common import MyBMWMockRouter
+
+
+@pytest.fixture
+def bmw_fixture(request: pytest.FixtureRequest) -> respx.MockRouter:
+    """Patch MyBMW login API calls."""
+    # Now we can start patching the API calls
+    router = MyBMWMockRouter(
+        vehicles_to_load=getattr(request, "param", []),
+        states=ALL_STATES,
+        charging_settings=ALL_CHARGING_SETTINGS,
+    )
+
+    with router:
+        yield router
+
+
+async def prepare_account_with_vehicles(region: Optional[Regions] = None, metric: bool = True):
+    """Initialize account and get vehicles."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION, use_metric_units=metric)
+    await account.get_vehicles()
+    return account

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for BMW tests."""
-from typing import Optional
+from typing import Generator, Optional
 
 try:
     from unittest import mock
@@ -27,7 +27,7 @@ from .common import MyBMWMockRouter
 
 
 @pytest.fixture
-def bmw_fixture(request: pytest.FixtureRequest) -> respx.MockRouter:
+def bmw_fixture(request: pytest.FixtureRequest) -> Generator[respx.MockRouter, None, None]:
     """Patch MyBMW login API calls."""
     # Now we can start patching the API calls
     router = MyBMWMockRouter(

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 from pathlib import Path
-from typing import Optional
 
 try:
     from unittest import mock
@@ -22,13 +21,10 @@ from bimmer_connected.account import ConnectedDriveAccount, MyBMWAccount
 from bimmer_connected.api.authentication import MyBMWAuthentication, MyBMWLoginRetry
 from bimmer_connected.api.client import MyBMWClient
 from bimmer_connected.api.regions import get_region_from_name
-from bimmer_connected.const import ATTR_CAPABILITIES, Regions
+from bimmer_connected.const import ATTR_CAPABILITIES
 from bimmer_connected.models import GPSPosition, MyBMWAPIError, MyBMWAuthError, MyBMWQuotaError
 
 from . import (
-    ALL_CHARGING_SETTINGS,
-    ALL_FINGERPRINTS,
-    ALL_STATES,
     RESPONSE_DIR,
     TEST_PASSWORD,
     TEST_REGION,
@@ -39,125 +35,19 @@ from . import (
     get_fingerprint_count,
     load_response,
 )
+from .conftest import prepare_account_with_vehicles
 
 
-def authenticate_sideeffect(request: httpx.Request) -> httpx.Response:
-    """Return /oauth/authentication response based on request."""
-    request_text = request.read().decode("UTF-8")
-    if "username" in request_text and "password" in request_text and "grant_type" in request_text:
-        return httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "authorization_response.json"))
-    return httpx.Response(
-        302,
-        headers={
-            "Location": "com.mini.connected://oauth?code=CODE&state=STATE&client_id=CLIENT_ID&nonce=login_nonce",
-        },
-    )
-
-
-def vehicles_sideeffect(request: httpx.Request) -> httpx.Response:
-    """Return /vehicles response based on x-user-agent."""
-    x_user_agent = request.headers.get("x-user-agent", "").split(";")
-    if len(x_user_agent) == 4:
-        brand = x_user_agent[1]
-    else:
-        raise ValueError("x-user-agent not configured correctly!")
-
-    # Test if given region is valid
-    _ = Regions(x_user_agent[3])
-
-    return httpx.Response(200, json=ALL_FINGERPRINTS.get(brand, []))
-
-
-def vehicle_state_sideeffect(request: httpx.Request) -> httpx.Response:
-    """Return /vehicles response based on x-user-agent."""
-    x_user_agent = request.headers.get("x-user-agent", "").split(";")
-    assert len(x_user_agent) == 4
-
-    try:
-        return httpx.Response(200, json=ALL_STATES[request.headers["bmw-vin"]])
-    except KeyError:
-        return httpx.Response(404)
-
-
-def vehicle_charging_settings_sideeffect(request: httpx.Request) -> httpx.Response:
-    """Return /vehicles response based on x-user-agent."""
-    x_user_agent = request.headers.get("x-user-agent", "").split(";")
-    assert len(x_user_agent) == 4
-    assert "fields" in request.url.params
-    assert "has_charging_settings_capabilities" in request.url.params
-
-    try:
-        return httpx.Response(200, json=ALL_CHARGING_SETTINGS[request.headers["bmw-vin"]])
-    except KeyError:
-        return httpx.Response(404)
-
-
-def account_mock():
-    """Return mocked adapter for auth."""
-    router = respx.mock(assert_all_called=False)
-
-    # Login to north_america and rest_of_world
-    router.get("/eadrax-ucs/v1/presentation/oauth/config").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "oauth_config.json")
-    )
-    router.post("/gcdm/oauth/authenticate").mock(side_effect=authenticate_sideeffect)
-    router.post("/gcdm/oauth/token").respond(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json"))
-
-    # Login to china
-    router.get("/eadrax-coas/v1/cop/publickey").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_publickey.json")
-    )
-    router.post("/eadrax-coas/v2/cop/slider-captcha").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha.json")
-    )
-
-    router.post("/eadrax-coas/v1/cop/check-captcha").mock(
-        side_effect=[
-            httpx.Response(422),
-            httpx.Response(201, json=load_response(RESPONSE_DIR / "auth" / "auth_slider_captcha_check.json")),
-        ]
-    )
-
-    router.post("/eadrax-coas/v2/login/pwd").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_pwd.json")
-    )
-    router.post("/eadrax-coas/v2/oauth/token").respond(
-        200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")
-    )
-
-    # Get all vehicle fingerprints
-    router.get("/eadrax-vcs/v4/vehicles").mock(side_effect=vehicles_sideeffect)
-    router.get("/eadrax-vcs/v4/vehicles/state").mock(side_effect=vehicle_state_sideeffect)
-    router.get("/eadrax-crccs/v2/vehicles").mock(side_effect=vehicle_charging_settings_sideeffect)
-
-    return router
-
-
-def get_account(region: Optional[Regions] = None, metric: bool = True):
-    """Return account without token and vehicles (sync)."""
-    return MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION, use_metric_units=metric)
-
-
-async def get_mocked_account(region: Optional[Regions] = None, metric: bool = True):
-    """Return pre-mocked account."""
-    with account_mock():
-        account = get_account(region, metric)
-        await account.get_vehicles()
-    return account
-
-
-@account_mock()
 @pytest.mark.asyncio
-async def test_login_row_na():
+async def test_login_row_na(bmw_fixture: respx.Router):
     """Test the login flow."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
     await account.get_vehicles()
     assert account is not None
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_login_refresh_token_row_na_expired():
+async def test_login_refresh_token_row_na_expired(bmw_fixture: respx.Router):
     """Test the login flow using refresh_token."""
     with mock.patch("bimmer_connected.api.authentication.EXPIRES_AT_OFFSET", datetime.timedelta(seconds=30000)):
         account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
@@ -176,61 +66,58 @@ async def test_login_refresh_token_row_na_expired():
 
 
 @pytest.mark.asyncio
-async def test_login_refresh_token_row_na_401():
+async def test_login_refresh_token_row_na_401(bmw_fixture: respx.Router):
     """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
-        await account.get_vehicles()
 
-        with mock.patch(
-            "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_row_na",
-            wraps=account.config.authentication._refresh_token_row_na,
-        ) as mock_listener:
-            mock_api.get("/eadrax-vcs/v4/vehicles/state").mock(
-                side_effect=[httpx.Response(401), *([httpx.Response(200, json={ATTR_CAPABILITIES: {}})] * 10)]
-            )
-            mock_listener.reset_mock()
-            await account.get_vehicles()
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
+    await account.get_vehicles()
 
-            assert mock_listener.call_count == 1
-            assert account.config.authentication.refresh_token is not None
-
-
-@pytest.mark.asyncio
-async def test_login_refresh_token_row_na_invalid(caplog):
-    """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        mock_api.post("/gcdm/oauth/token").mock(
-            side_effect=[
-                httpx.Response(400),
-                httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")),
-            ]
+    with mock.patch(
+        "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_row_na",
+        wraps=account.config.authentication._refresh_token_row_na,
+    ) as mock_listener:
+        bmw_fixture.get("/eadrax-vcs/v4/vehicles/state").mock(
+            side_effect=[httpx.Response(401), *([httpx.Response(200, json={ATTR_CAPABILITIES: {}})] * 10)]
         )
-
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
-        account.set_refresh_token("INVALID")
-
-        caplog.set_level(logging.DEBUG)
+        mock_listener.reset_mock()
         await account.get_vehicles()
 
-        debug_messages = [r.message for r in caplog.records if r.name.startswith("bimmer_connected")]
-        assert "Authenticating with refresh token for North America & Rest of World." in debug_messages
-        assert "Unable to get access token using refresh token, falling back to username/password." in debug_messages
-        assert "Authenticating with MyBMW flow for North America & Rest of World." in debug_messages
+        assert mock_listener.call_count == 1
+        assert account.config.authentication.refresh_token is not None
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_login_china():
+async def test_login_refresh_token_row_na_invalid(caplog, bmw_fixture: respx.Router):
+    """Test the login flow using refresh_token."""
+    bmw_fixture.post("/gcdm/oauth/token").mock(
+        side_effect=[
+            httpx.Response(400),
+            httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")),
+        ]
+    )
+
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name(TEST_REGION_STRING))
+    account.set_refresh_token("INVALID")
+
+    caplog.set_level(logging.DEBUG)
+    await account.get_vehicles()
+
+    debug_messages = [r.message for r in caplog.records if r.name.startswith("bimmer_connected")]
+    assert "Authenticating with refresh token for North America & Rest of World." in debug_messages
+    assert "Unable to get access token using refresh token, falling back to username/password." in debug_messages
+    assert "Authenticating with MyBMW flow for North America & Rest of World." in debug_messages
+
+
+@pytest.mark.asyncio
+async def test_login_china(bmw_fixture: respx.Router):
     """Test the login flow for region `china`."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
     await account.get_vehicles()
     assert account is not None
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_login_refresh_token_china_expired():
+async def test_login_refresh_token_china_expired(bmw_fixture: respx.Router):
     """Test the login flow using refresh_token  for region `china`."""
     with mock.patch("bimmer_connected.api.authentication.EXPIRES_AT_OFFSET", datetime.timedelta(seconds=30000)):
         account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
@@ -249,52 +136,49 @@ async def test_login_refresh_token_china_expired():
 
 
 @pytest.mark.asyncio
-async def test_login_refresh_token_china_401():
+async def test_login_refresh_token_china_401(bmw_fixture: respx.Router):
     """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
-        await account.get_vehicles()
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
+    await account.get_vehicles()
 
-        with mock.patch(
-            "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_china",
-            wraps=account.config.authentication._refresh_token_china,
-        ) as mock_listener:
-            mock_api.get("/eadrax-vcs/v4/vehicles/state").mock(
-                side_effect=[httpx.Response(401), *([httpx.Response(200, json={ATTR_CAPABILITIES: {}})] * 10)]
-            )
-            mock_listener.reset_mock()
-            await account.get_vehicles()
-
-            assert mock_listener.call_count == 1
-            assert account.config.authentication.refresh_token is not None
-
-
-@pytest.mark.asyncio
-async def test_login_refresh_token_china_invalid(caplog):
-    """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        mock_api.post("/eadrax-coas/v2/oauth/token").mock(
-            side_effect=[
-                httpx.Response(400),
-                httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")),
-            ]
+    with mock.patch(
+        "bimmer_connected.api.authentication.MyBMWAuthentication._refresh_token_china",
+        wraps=account.config.authentication._refresh_token_china,
+    ) as mock_listener:
+        bmw_fixture.get("/eadrax-vcs/v4/vehicles/state").mock(
+            side_effect=[httpx.Response(401), *([httpx.Response(200, json={ATTR_CAPABILITIES: {}})] * 10)]
         )
-
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
-        account.set_refresh_token("INVALID")
-
-        caplog.set_level(logging.DEBUG)
+        mock_listener.reset_mock()
         await account.get_vehicles()
 
-        debug_messages = [r.message for r in caplog.records if r.name.startswith("bimmer_connected")]
-        assert "Authenticating with refresh token for China." in debug_messages
-        assert "Unable to get access token using refresh token, falling back to username/password." in debug_messages
-        assert "Authenticating with MyBMW flow for China." in debug_messages
+        assert mock_listener.call_count == 1
+        assert account.config.authentication.refresh_token is not None
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_vehicles():
+async def test_login_refresh_token_china_invalid(caplog, bmw_fixture: respx.Router):
+    """Test the login flow using refresh_token."""
+    bmw_fixture.post("/eadrax-coas/v2/oauth/token").mock(
+        side_effect=[
+            httpx.Response(400),
+            httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "auth_token.json")),
+        ]
+    )
+
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
+    account.set_refresh_token("INVALID")
+
+    caplog.set_level(logging.DEBUG)
+    await account.get_vehicles()
+
+    debug_messages = [r.message for r in caplog.records if r.name.startswith("bimmer_connected")]
+    assert "Authenticating with refresh token for China." in debug_messages
+    assert "Unable to get access token using refresh token, falling back to username/password." in debug_messages
+    assert "Authenticating with MyBMW flow for China." in debug_messages
+
+
+@pytest.mark.asyncio
+async def test_vehicles(bmw_fixture: respx.Router):
     """Test the login flow."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
     await account.get_vehicles()
@@ -303,14 +187,14 @@ async def test_vehicles():
     assert get_fingerprint_count() == len(account.vehicles)
 
     vehicle = account.get_vehicle(VIN_G26)
+    assert vehicle is not None
     assert VIN_G26 == vehicle.vin
 
     assert account.get_vehicle("invalid_vin") is None
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_vehicle_init():
+async def test_vehicle_init(bmw_fixture: respx.Router):
     """Test vehicle initialization."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
     with mock.patch(
@@ -335,45 +219,42 @@ async def test_vehicle_init():
 
 
 @pytest.mark.asyncio
-async def test_invalid_password():
+async def test_invalid_password(bmw_fixture: respx.Router):
     """Test parsing the results of an invalid password."""
-    with account_mock() as mock_api:
-        mock_api.post("/gcdm/oauth/authenticate").respond(
-            401, json=load_response(RESPONSE_DIR / "auth" / "auth_error_wrong_password.json")
-        )
-        with pytest.raises(MyBMWAuthError):
-            account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-            await account.get_vehicles()
+    bmw_fixture.post("/gcdm/oauth/authenticate").respond(
+        401, json=load_response(RESPONSE_DIR / "auth" / "auth_error_wrong_password.json")
+    )
+    with pytest.raises(MyBMWAuthError):
+        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+        await account.get_vehicles()
 
 
 @pytest.mark.asyncio
-async def test_invalid_password_china():
+async def test_invalid_password_china(bmw_fixture: respx.Router):
     """Test parsing the results of an invalid password."""
-    with account_mock() as mock_api:
-        mock_api.post("/eadrax-coas/v2/login/pwd").respond(
-            422, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_error.json")
-        )
-        with pytest.raises(MyBMWAPIError):
-            account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
-            await account.get_vehicles()
+    bmw_fixture.post("/eadrax-coas/v2/login/pwd").respond(
+        422, json=load_response(RESPONSE_DIR / "auth" / "auth_cn_login_error.json")
+    )
+    with pytest.raises(MyBMWAPIError):
+        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
+        await account.get_vehicles()
 
 
 @pytest.mark.asyncio
-async def test_server_error():
+async def test_server_error(bmw_fixture: respx.Router):
     """Test parsing the results of a server error."""
-    with account_mock() as mock_api:
-        mock_api.post("/gcdm/oauth/authenticate").respond(
-            500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
-        )
-        with pytest.raises(MyBMWAPIError):
-            account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-            await account.get_vehicles()
+    bmw_fixture.post("/gcdm/oauth/authenticate").respond(
+        500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
+    )
+    with pytest.raises(MyBMWAPIError):
+        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+        await account.get_vehicles()
 
 
 @pytest.mark.asyncio
-async def test_vehicle_search_case():
+async def test_vehicle_search_case(bmw_fixture: respx.Router):
     """Check if the search for the vehicle by VIN is NOT case sensitive."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     vin = account.vehicles[1].vin
     assert vin == account.get_vehicle(vin).vin
@@ -382,17 +263,16 @@ async def test_vehicle_search_case():
 
 
 @pytest.mark.asyncio
-async def test_get_fingerprints():
+async def test_get_fingerprints(bmw_fixture: respx.Router):
     """Test getting fingerprints."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION, log_responses=True)
-        await account.get_vehicles()
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION, log_responses=True)
+    await account.get_vehicles()
 
-        mock_api.get("/eadrax-vcs/v4/vehicles/state").respond(
-            500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
-        )
-        with pytest.raises(MyBMWAPIError):
-            await account.get_vehicles()
+    bmw_fixture.get("/eadrax-vcs/v4/vehicles/state").respond(
+        500, text=load_response(RESPONSE_DIR / "auth" / "auth_error_internal_error.txt")
+    )
+    with pytest.raises(MyBMWAPIError):
+        await account.get_vehicles()
 
     filenames = [Path(f.filename) for f in account.get_stored_responses()]
     json_files = [f for f in filenames if f.suffix == ".json"]
@@ -403,9 +283,9 @@ async def test_get_fingerprints():
 
 
 @pytest.mark.asyncio
-async def test_set_observer_value():
+async def test_set_observer_value(bmw_fixture: respx.Router):
     """Test set_observer_position with valid arguments."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     account.set_observer_position(1.0, 2.0)
 
@@ -413,9 +293,9 @@ async def test_set_observer_value():
 
 
 @pytest.mark.asyncio
-async def test_set_observer_not_set():
+async def test_set_observer_not_set(bmw_fixture: respx.Router):
     """Test set_observer_position with no arguments."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     assert account.config.observer_position is None
 
@@ -425,9 +305,9 @@ async def test_set_observer_not_set():
 
 
 @pytest.mark.asyncio
-async def test_set_observer_invalid_values():
+async def test_set_observer_invalid_values(bmw_fixture: respx.Router):
     """Test set_observer_position with invalid arguments."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     with pytest.raises(TypeError):
         account.set_observer_position(None, 2.0)
@@ -459,9 +339,8 @@ async def test_set_use_metric_units():
     assert imperial_client.generate_default_header()["bmw-units-preferences"] == "d=MI;v=G"
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_deprecated_account(caplog):
+async def test_deprecated_account(caplog, bmw_fixture: respx.Router):
     """Test deprecation warning for ConnectedDriveAccount."""
     account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
     await account.get_vehicles()
@@ -470,9 +349,8 @@ async def test_deprecated_account(caplog):
     assert 1 == len(get_deprecation_warning_count(caplog))
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_refresh_token_getset():
+async def test_refresh_token_getset(bmw_fixture: respx.Router):
     """Test getting/setting the refresh_token and gcid."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
     assert account.refresh_token is None
@@ -494,134 +372,128 @@ async def test_refresh_token_getset():
 
 
 @pytest.mark.asyncio
-async def test_429_retry_ok_login(caplog):
+async def test_429_retry_ok_login(caplog, bmw_fixture: respx.Router):
     """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
 
-        json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
+    json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
 
-        mock_api.get("/eadrax-ucs/v1/presentation/oauth/config").mock(
-            side_effect=[
-                httpx.Response(429, json=json_429),
-                httpx.Response(429, json=json_429),
-                httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "oauth_config.json")),
-            ]
-        )
-        caplog.set_level(logging.DEBUG)
-
-        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
-            await account.get_vehicles()
-
-        log_429 = [
-            r
-            for r in caplog.records
-            if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
+    bmw_fixture.get("/eadrax-ucs/v1/presentation/oauth/config").mock(
+        side_effect=[
+            httpx.Response(429, json=json_429),
+            httpx.Response(429, json=json_429),
+            httpx.Response(200, json=load_response(RESPONSE_DIR / "auth" / "oauth_config.json")),
         ]
-        assert len(log_429) == 2
+    )
+    caplog.set_level(logging.DEBUG)
 
-
-@pytest.mark.asyncio
-async def test_429_retry_raise_login(caplog):
-    """Test the login flow using refresh_token."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-
-        json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
-
-        mock_api.get("/eadrax-ucs/v1/presentation/oauth/config").mock(return_value=httpx.Response(429, json=json_429))
-        caplog.set_level(logging.DEBUG)
-
-        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
-            with pytest.raises(MyBMWAPIError):
-                await account.get_vehicles()
-
-        log_429 = [
-            r
-            for r in caplog.records
-            if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
-        ]
-        assert len(log_429) == 3
-
-
-@pytest.mark.asyncio
-async def test_429_retry_ok_vehicles(caplog):
-    """Test waiting on 429 for vehicles."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-
-        json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
-
-        mock_api.get("/eadrax-vcs/v4/vehicles").mock(
-            side_effect=[
-                httpx.Response(429, json=json_429),
-                httpx.Response(429, json=json_429),
-                *[httpx.Response(200, json=[])] * 2,
-            ]
-        )
-        caplog.set_level(logging.DEBUG)
-
-        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
-            await account.get_vehicles()
-
-        log_429 = [
-            r
-            for r in caplog.records
-            if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
-        ]
-        assert len(log_429) == 2
-
-
-@pytest.mark.asyncio
-async def test_429_retry_raise_vehicles(caplog):
-    """Test waiting on 429 for vehicles and fail if it happens too often."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-
-        json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
-
-        mock_api.get("/eadrax-vcs/v4/vehicles").mock(return_value=httpx.Response(429, json=json_429))
-        caplog.set_level(logging.DEBUG)
-
-        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
-            with pytest.raises(MyBMWQuotaError):
-                await account.get_vehicles()
-
-        log_429 = [
-            r
-            for r in caplog.records
-            if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
-        ]
-        assert len(log_429) == 3
-
-
-@pytest.mark.asyncio
-async def test_403_quota_exceeded_vehicles_usa(caplog):
-    """Test 403 quota issues for vehicle state and fail if it happens too often."""
-    with account_mock() as mock_api:
-        account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
-        # get vehicles once
+    with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
         await account.get_vehicles()
 
-        mock_api.get("/eadrax-vcs/v4/vehicles/state").mock(
-            return_value=httpx.Response(
-                403,
-                json={"statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 02:12:20."},
-            )
-        )
-        caplog.set_level(logging.DEBUG)
-
-        with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
-            with pytest.raises(MyBMWQuotaError):
-                await account.get_vehicles()
-
-        log_quota = [r for r in caplog.records if "quota" in r.message]
-        assert len(log_quota) == 1
+    log_429 = [
+        r
+        for r in caplog.records
+        if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
+    ]
+    assert len(log_429) == 2
 
 
-@account_mock()
 @pytest.mark.asyncio
-async def test_client_async_only():
+async def test_429_retry_raise_login(caplog, bmw_fixture: respx.Router):
+    """Test the login flow using refresh_token."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+
+    json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
+
+    bmw_fixture.get("/eadrax-ucs/v1/presentation/oauth/config").mock(return_value=httpx.Response(429, json=json_429))
+    caplog.set_level(logging.DEBUG)
+
+    with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+        with pytest.raises(MyBMWAPIError):
+            await account.get_vehicles()
+
+    log_429 = [
+        r
+        for r in caplog.records
+        if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
+    ]
+    assert len(log_429) == 3
+
+
+@pytest.mark.asyncio
+async def test_429_retry_ok_vehicles(caplog, bmw_fixture: respx.Router):
+    """Test waiting on 429 for vehicles."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+
+    json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
+
+    bmw_fixture.get("/eadrax-vcs/v4/vehicles").mock(
+        side_effect=[
+            httpx.Response(429, json=json_429),
+            httpx.Response(429, json=json_429),
+            *[httpx.Response(200, json=[])] * 2,
+        ]
+    )
+    caplog.set_level(logging.DEBUG)
+
+    with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+        await account.get_vehicles()
+
+    log_429 = [
+        r
+        for r in caplog.records
+        if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
+    ]
+    assert len(log_429) == 2
+
+
+@pytest.mark.asyncio
+async def test_429_retry_raise_vehicles(caplog, bmw_fixture: respx.Router):
+    """Test waiting on 429 for vehicles and fail if it happens too often."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+
+    json_429 = {"statusCode": 429, "message": "Rate limit is exceeded. Try again in 2 seconds."}
+
+    bmw_fixture.get("/eadrax-vcs/v4/vehicles").mock(return_value=httpx.Response(429, json=json_429))
+    caplog.set_level(logging.DEBUG)
+
+    with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+        with pytest.raises(MyBMWQuotaError):
+            await account.get_vehicles()
+
+    log_429 = [
+        r
+        for r in caplog.records
+        if r.module == "authentication" and "seconds due to 429 Too Many Requests" in r.message
+    ]
+    assert len(log_429) == 3
+
+
+@pytest.mark.asyncio
+async def test_403_quota_exceeded_vehicles_usa(caplog, bmw_fixture: respx.Router):
+    """Test 403 quota issues for vehicle state and fail if it happens too often."""
+    account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+    # get vehicles once
+    await account.get_vehicles()
+
+    bmw_fixture.get("/eadrax-vcs/v4/vehicles/state").mock(
+        return_value=httpx.Response(
+            403,
+            json={"statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 02:12:20."},
+        )
+    )
+    caplog.set_level(logging.DEBUG)
+
+    with mock.patch("asyncio.sleep", new_callable=mock.AsyncMock):
+        with pytest.raises(MyBMWQuotaError):
+            await account.get_vehicles()
+
+    log_quota = [r for r in caplog.records if "quota" in r.message]
+    assert len(log_quota) == 1
+
+
+@pytest.mark.asyncio
+async def test_client_async_only(bmw_fixture: respx.Router):
     """Test that the Authentication providers only work async."""
 
     with httpx.Client(auth=MyBMWAuthentication(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)) as client:

--- a/test/test_deprecated_vehicle.py
+++ b/test/test_deprecated_vehicle.py
@@ -1,5 +1,6 @@
 """Tests for deprecated MyBMWVehicle."""
 import pytest
+import respx
 
 from bimmer_connected.const import CarBrands
 from bimmer_connected.vehicle.vehicle import ConnectedDriveVehicle
@@ -15,7 +16,7 @@ from . import (
     VIN_I20,
     get_deprecation_warning_count,
 )
-from .test_account import get_mocked_account
+from .conftest import prepare_account_with_vehicles
 
 ATTRIBUTE_MAPPING = {
     "remainingFuel": "remaining_fuel",
@@ -36,9 +37,9 @@ ATTRIBUTE_MAPPING = {
 
 
 @pytest.mark.asyncio
-async def test_parsing_attributes(caplog):
+async def test_parsing_attributes(caplog, bmw_fixture: respx.router):
     """Test parsing different attributes of the vehicle."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     for vehicle in account.vehicles:
         print(vehicle.name)
@@ -54,9 +55,9 @@ async def test_parsing_attributes(caplog):
 
 
 @pytest.mark.asyncio
-async def test_drive_train_attributes(caplog):
+async def test_drive_train_attributes(caplog, bmw_fixture: respx.router):
     """Test parsing different attributes of the vehicle."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     vehicle_drivetrains = {
         VIN_F31: (True, False, False),
@@ -78,9 +79,9 @@ async def test_drive_train_attributes(caplog):
 
 
 @pytest.mark.asyncio
-async def test_deprecated_vehicle(caplog):
+async def test_deprecated_vehicle(caplog, bmw_fixture: respx.router):
     """Test deprecation warning for ConnectedDriveVehicle."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
 
     deprecated_vehicle = ConnectedDriveVehicle(account, account.vehicles[0].data)
 

--- a/test/test_deprecated_vehicle.py
+++ b/test/test_deprecated_vehicle.py
@@ -37,7 +37,7 @@ ATTRIBUTE_MAPPING = {
 
 
 @pytest.mark.asyncio
-async def test_parsing_attributes(caplog, bmw_fixture: respx.router):
+async def test_parsing_attributes(caplog, bmw_fixture: respx.Router):
     """Test parsing different attributes of the vehicle."""
     account = await prepare_account_with_vehicles()
 
@@ -55,7 +55,7 @@ async def test_parsing_attributes(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_drive_train_attributes(caplog, bmw_fixture: respx.router):
+async def test_drive_train_attributes(caplog, bmw_fixture: respx.Router):
     """Test parsing different attributes of the vehicle."""
     account = await prepare_account_with_vehicles()
 
@@ -79,7 +79,7 @@ async def test_drive_train_attributes(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_deprecated_vehicle(caplog, bmw_fixture: respx.router):
+async def test_deprecated_vehicle(caplog, bmw_fixture: respx.Router):
     """Test deprecation warning for ConnectedDriveVehicle."""
     account = await prepare_account_with_vehicles()
 

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -3,6 +3,7 @@
 import datetime
 
 import pytest
+import respx
 import time_machine
 
 from bimmer_connected.api.regions import get_region_from_name
@@ -12,13 +13,13 @@ from bimmer_connected.vehicle.reports import CheckControlStatus, ConditionBasedS
 from bimmer_connected.vehicle.vehicle import ConnectedDriveVehicle
 
 from . import VIN_F31, VIN_G01, VIN_G20, VIN_G26, VIN_I01_NOREX, VIN_I01_REX, VIN_I20, get_deprecation_warning_count
-from .test_account import get_mocked_account
+from .conftest import prepare_account_with_vehicles
 
 
 @pytest.mark.asyncio
-async def test_generic(caplog):
+async def test_generic(caplog, bmw_fixture: respx.router):
     """Test generic attributes."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G26).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
     expected = datetime.datetime(year=2023, month=1, day=4, hour=14, minute=57, second=6, tzinfo=datetime.timezone.utc)
     assert expected == status.timestamp
@@ -39,9 +40,9 @@ async def test_generic(caplog):
 
 
 @pytest.mark.asyncio
-async def test_range_combustion_no_info(caplog):
+async def test_range_combustion_no_info(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    status = (await get_mocked_account()).get_vehicle(VIN_F31).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_F31).status
 
     assert (14, "L") == status.remaining_fuel
     assert status.remaining_range_fuel == (None, None)
@@ -56,9 +57,9 @@ async def test_range_combustion_no_info(caplog):
 
 
 @pytest.mark.asyncio
-async def test_range_combustion(caplog):
+async def test_range_combustion(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G20).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G20).status
 
     assert (40, "L") == status.remaining_fuel
     assert (629, "km") == status.remaining_range_fuel
@@ -73,9 +74,9 @@ async def test_range_combustion(caplog):
 
 
 @pytest.mark.asyncio
-async def test_range_phev(caplog):
+async def test_range_phev(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G01).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
     assert (40, "L") == status.remaining_fuel
     assert (436, "km") == status.remaining_range_fuel
@@ -92,9 +93,9 @@ async def test_range_phev(caplog):
 
 
 @pytest.mark.asyncio
-async def test_range_rex(caplog):
+async def test_range_rex(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    status = (await get_mocked_account()).get_vehicle(VIN_I01_REX).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_I01_REX).status
 
     assert (6, "L") == status.remaining_fuel
     assert (105, "km") == status.remaining_range_fuel
@@ -111,9 +112,9 @@ async def test_range_rex(caplog):
 
 
 @pytest.mark.asyncio
-async def test_range_electric(caplog):
+async def test_range_electric(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G26).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
     assert status.remaining_fuel == (None, None)
     assert status.remaining_range_fuel == (None, None)
@@ -129,9 +130,9 @@ async def test_range_electric(caplog):
 
 @time_machine.travel("2021-11-28 21:28:59 +0000", tick=False)
 @pytest.mark.asyncio
-async def test_charging_end_time(caplog):
+async def test_charging_end_time(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
     status = account.get_vehicle(VIN_I01_NOREX).status
     assert datetime.datetime(2021, 11, 28, 23, 27, 59, tzinfo=datetime.timezone.utc) == status.charging_end_time
 
@@ -140,9 +141,9 @@ async def test_charging_end_time(caplog):
 
 
 @pytest.mark.asyncio
-async def test_charging_time_label(caplog):
+async def test_charging_time_label(caplog, bmw_fixture: respx.router):
     """Test if the parsing of mileage and range is working."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
     status = account.get_vehicle(VIN_I20).status
     assert None is status.charging_time_label
 
@@ -150,10 +151,10 @@ async def test_charging_time_label(caplog):
 
 
 @pytest.mark.asyncio
-async def test_plugged_in_waiting_for_charge_window(caplog):
+async def test_plugged_in_waiting_for_charge_window(caplog, bmw_fixture: respx.router):
     """G01 is plugged in but not charging, as its waiting for charging window."""
     # Should be None on G01 as it is only "charging"
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
     vehicle = account.get_vehicle(VIN_I01_REX)
 
     assert vehicle.status.charging_end_time is None
@@ -164,9 +165,9 @@ async def test_plugged_in_waiting_for_charge_window(caplog):
 
 
 @pytest.mark.asyncio
-async def test_condition_based_services(caplog):
+async def test_condition_based_services(caplog, bmw_fixture: respx.router):
     """Test condition based service messages."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G26).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
     cbs = status.condition_based_services
     assert 5 == len(cbs)
@@ -191,9 +192,9 @@ async def test_condition_based_services(caplog):
 
 
 @pytest.mark.asyncio
-async def test_parse_f31_no_position(caplog):
+async def test_parse_f31_no_position(caplog, bmw_fixture: respx.router):
     """Test parsing of F31 data with position tracking disabled in the vehicle."""
-    status = (await get_mocked_account()).get_vehicle(VIN_F31).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_F31).status
 
     assert status.gps_position is None
     assert status.gps_heading is None
@@ -202,9 +203,9 @@ async def test_parse_f31_no_position(caplog):
 
 
 @pytest.mark.asyncio
-async def test_parse_gcj02_position(caplog):
+async def test_parse_gcj02_position(caplog, bmw_fixture: respx.router):
     """Test conversion of GCJ02 to WGS84 for china."""
-    account = await get_mocked_account(get_region_from_name("china"))
+    account = await prepare_account_with_vehicles(get_region_from_name("china"))
     vehicle = account.get_vehicle(VIN_G01)
     vehicle = ConnectedDriveVehicle(account, vehicle.data)
     vehicle.update_state(
@@ -228,15 +229,15 @@ async def test_parse_gcj02_position(caplog):
 
 
 @pytest.mark.asyncio
-async def test_lids(caplog):
+async def test_lids(caplog, bmw_fixture: respx.router):
     """Test features around lids."""
-    # status = (await get_mocked_account()).get_vehicle(VIN_G30).status
+    # status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G30).status
 
     # assert 6 == len(list(status.lids))
     # assert 3 == len(list(status.open_lids))
     # assert status.all_lids_closed is False
 
-    status = (await get_mocked_account()).get_vehicle(VIN_G26).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
     for lid in status.lids:
         assert LidState.CLOSED == lid.state
@@ -248,9 +249,9 @@ async def test_lids(caplog):
 
 
 @pytest.mark.asyncio
-async def test_windows_g31(caplog):
+async def test_windows_g31(caplog, bmw_fixture: respx.router):
     """Test features around windows."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G01).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
     for window in status.windows:
         assert LidState.CLOSED == window.state
@@ -263,13 +264,13 @@ async def test_windows_g31(caplog):
 
 
 @pytest.mark.asyncio
-async def test_door_locks(caplog):
+async def test_door_locks(caplog, bmw_fixture: respx.router):
     """Test the door locks."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G01).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
     assert LockState.LOCKED == status.door_lock_state
 
-    status = (await get_mocked_account()).get_vehicle(VIN_I01_REX).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_I01_REX).status
 
     assert LockState.UNLOCKED == status.door_lock_state
 
@@ -277,13 +278,13 @@ async def test_door_locks(caplog):
 
 
 @pytest.mark.asyncio
-async def test_check_control_messages(caplog):
+async def test_check_control_messages(caplog, bmw_fixture: respx.router):
     """Test handling of check control messages.
 
     F11 is the only vehicle with active Check Control Messages, so we only expect to get something there.
     However we have no vehicle with issues in check control.
     """
-    vehicle = (await get_mocked_account()).get_vehicle(VIN_G01)
+    vehicle = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01)
     assert vehicle.status.has_check_control_messages is True
 
     ccms = vehicle.status.check_control_messages
@@ -297,9 +298,9 @@ async def test_check_control_messages(caplog):
 
 
 @pytest.mark.asyncio
-async def test_functions_without_data(caplog):
+async def test_functions_without_data(caplog, bmw_fixture: respx.router):
     """Test functions that do not return any result anymore."""
-    status = (await get_mocked_account()).get_vehicle(VIN_G01).status
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
     assert status.last_charging_end_result is None
     assert status.parking_lights is None

--- a/test/test_deprecated_vehicle_status.py
+++ b/test/test_deprecated_vehicle_status.py
@@ -17,7 +17,7 @@ from .conftest import prepare_account_with_vehicles
 
 
 @pytest.mark.asyncio
-async def test_generic(caplog, bmw_fixture: respx.router):
+async def test_generic(caplog, bmw_fixture: respx.Router):
     """Test generic attributes."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
@@ -40,7 +40,7 @@ async def test_generic(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_range_combustion_no_info(caplog, bmw_fixture: respx.router):
+async def test_range_combustion_no_info(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_F31).status
 
@@ -57,7 +57,7 @@ async def test_range_combustion_no_info(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_range_combustion(caplog, bmw_fixture: respx.router):
+async def test_range_combustion(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G20).status
 
@@ -74,7 +74,7 @@ async def test_range_combustion(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_range_phev(caplog, bmw_fixture: respx.router):
+async def test_range_phev(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
@@ -93,7 +93,7 @@ async def test_range_phev(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_range_rex(caplog, bmw_fixture: respx.router):
+async def test_range_rex(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_I01_REX).status
 
@@ -112,7 +112,7 @@ async def test_range_rex(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_range_electric(caplog, bmw_fixture: respx.router):
+async def test_range_electric(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
@@ -130,7 +130,7 @@ async def test_range_electric(caplog, bmw_fixture: respx.router):
 
 @time_machine.travel("2021-11-28 21:28:59 +0000", tick=False)
 @pytest.mark.asyncio
-async def test_charging_end_time(caplog, bmw_fixture: respx.router):
+async def test_charging_end_time(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     account = await prepare_account_with_vehicles()
     status = account.get_vehicle(VIN_I01_NOREX).status
@@ -141,7 +141,7 @@ async def test_charging_end_time(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_charging_time_label(caplog, bmw_fixture: respx.router):
+async def test_charging_time_label(caplog, bmw_fixture: respx.Router):
     """Test if the parsing of mileage and range is working."""
     account = await prepare_account_with_vehicles()
     status = account.get_vehicle(VIN_I20).status
@@ -151,7 +151,7 @@ async def test_charging_time_label(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_plugged_in_waiting_for_charge_window(caplog, bmw_fixture: respx.router):
+async def test_plugged_in_waiting_for_charge_window(caplog, bmw_fixture: respx.Router):
     """G01 is plugged in but not charging, as its waiting for charging window."""
     # Should be None on G01 as it is only "charging"
     account = await prepare_account_with_vehicles()
@@ -165,7 +165,7 @@ async def test_plugged_in_waiting_for_charge_window(caplog, bmw_fixture: respx.r
 
 
 @pytest.mark.asyncio
-async def test_condition_based_services(caplog, bmw_fixture: respx.router):
+async def test_condition_based_services(caplog, bmw_fixture: respx.Router):
     """Test condition based service messages."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26).status
 
@@ -192,7 +192,7 @@ async def test_condition_based_services(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_parse_f31_no_position(caplog, bmw_fixture: respx.router):
+async def test_parse_f31_no_position(caplog, bmw_fixture: respx.Router):
     """Test parsing of F31 data with position tracking disabled in the vehicle."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_F31).status
 
@@ -203,7 +203,7 @@ async def test_parse_f31_no_position(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_parse_gcj02_position(caplog, bmw_fixture: respx.router):
+async def test_parse_gcj02_position(caplog, bmw_fixture: respx.Router):
     """Test conversion of GCJ02 to WGS84 for china."""
     account = await prepare_account_with_vehicles(get_region_from_name("china"))
     vehicle = account.get_vehicle(VIN_G01)
@@ -229,7 +229,7 @@ async def test_parse_gcj02_position(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_lids(caplog, bmw_fixture: respx.router):
+async def test_lids(caplog, bmw_fixture: respx.Router):
     """Test features around lids."""
     # status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G30).status
 
@@ -249,7 +249,7 @@ async def test_lids(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_windows_g31(caplog, bmw_fixture: respx.router):
+async def test_windows_g31(caplog, bmw_fixture: respx.Router):
     """Test features around windows."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
@@ -264,7 +264,7 @@ async def test_windows_g31(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_door_locks(caplog, bmw_fixture: respx.router):
+async def test_door_locks(caplog, bmw_fixture: respx.Router):
     """Test the door locks."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 
@@ -278,7 +278,7 @@ async def test_door_locks(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_check_control_messages(caplog, bmw_fixture: respx.router):
+async def test_check_control_messages(caplog, bmw_fixture: respx.Router):
     """Test handling of check control messages.
 
     F11 is the only vehicle with active Check Control Messages, so we only expect to get something there.
@@ -298,7 +298,7 @@ async def test_check_control_messages(caplog, bmw_fixture: respx.router):
 
 
 @pytest.mark.asyncio
-async def test_functions_without_data(caplog, bmw_fixture: respx.router):
+async def test_functions_without_data(caplog, bmw_fixture: respx.Router):
     """Test functions that do not return any result anymore."""
     status = (await prepare_account_with_vehicles()).get_vehicle(VIN_G01).status
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,19 +8,20 @@ except ImportError:
     from backports import zoneinfo  # type: ignore[import, no-redef]
 
 import pytest
+import respx
 import time_machine
 
 from bimmer_connected.models import ChargingSettings, ValueWithUnit
 from bimmer_connected.utils import MyBMWJSONEncoder, get_class_property_names, parse_datetime
 
 from . import VIN_G26
-from .test_account import get_mocked_account
+from .conftest import prepare_account_with_vehicles
 
 
 @pytest.mark.asyncio
-async def test_drive_train():
+async def test_drive_train(bmw_fixture: respx.Router):
     """Tests available attribute."""
-    vehicle = (await get_mocked_account()).get_vehicle(VIN_G26)
+    vehicle = (await prepare_account_with_vehicles()).get_vehicle(VIN_G26)
     assert [
         "available_attributes",
         "brand",
@@ -77,9 +78,9 @@ def test_parse_datetime(caplog):
     tick=False,
 )
 @pytest.mark.asyncio
-async def test_account_timezone():
+async def test_account_timezone(bmw_fixture: respx.Router):
     """Test the timezone in MyBMWAccount."""
-    account = await get_mocked_account()
+    account = await prepare_account_with_vehicles()
     assert account.utcdiff == 960
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR tries to clean up tests.

We now use a conftest.py and pytest fixture for all our API calls (as in the Home Assistant tests).

While at it, the vehicle state inside a test function can now be updated (e.g. by remote service sideeffects), so we can check if remote service changes actually change the vehicle state.
While this is not so important in the lib, this is a major step that could be used in HA testing (change switch, execute remote service, check HA final state).
For this to work we probably have to move our tests inline, i.e. deploy them with the library (not in scope of this PR).

Also found and fixed an issue where pre-climatization could never be turned off using our remote service.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
