### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
       - name: Install dependencies
         run: |
@@ -71,7 +72,7 @@ jobs:
       - name: Test with black
         run: |
           black --check bimmer_connected
-  
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/bimmer_connected/__init__.py
+++ b/bimmer_connected/__init__.py
@@ -8,6 +8,11 @@ Disclaimer:
 This library is not affiliated with or endorsed by BMW Group.
 """
 
-import pkg_resources  # part of setuptools
+import sys
 
-__version__ = pkg_resources.get_distribution("bimmer_connected").version
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
+
+__version__ = version("bimmer_connected")

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -197,7 +197,7 @@ class MyBMWAuthentication(httpx.Auth):
             code = response.next_request.url.params["code"]
 
             # With code, get token
-            current_utc_time = datetime.datetime.utcnow()
+            current_utc_time = datetime.datetime.now(tz=datetime.timezone.utc)
             response = await client.post(
                 oauth_settings["tokenEndpoint"],
                 data={
@@ -237,7 +237,7 @@ class MyBMWAuthentication(httpx.Auth):
                 oauth_settings = r_oauth_settings.json()
 
                 # With code, get token
-                current_utc_time = datetime.datetime.utcnow()
+                current_utc_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 response = await client.post(
                     oauth_settings["tokenEndpoint"],
                     data={
@@ -314,7 +314,7 @@ class MyBMWAuthentication(httpx.Auth):
 
         return {
             "access_token": response_json["access_token"],
-            "expires_at": datetime.datetime.utcfromtimestamp(decoded_token["exp"]),
+            "expires_at": datetime.datetime.fromtimestamp(decoded_token["exp"], tz=datetime.timezone.utc),
             "refresh_token": response_json["refresh_token"],
             "gcid": response_json["gcid"],
         }
@@ -324,7 +324,7 @@ class MyBMWAuthentication(httpx.Auth):
             async with MyBMWLoginClient(region=self.region) as client:
                 _LOGGER.debug("Authenticating with refresh token for China.")
 
-                current_utc_time = datetime.datetime.utcnow()
+                current_utc_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
                 # Try logging in using refresh_token
                 response = await client.post(

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -169,7 +169,8 @@ def generate_cn_nonce(username: str) -> str:
     possible_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
     random_str = "".join(random.choice(possible_chars) for _ in range(8))
 
-    phone_text = f"{username}&{datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')}&{random_str}"
+    time_str = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    phone_text = f"{username}&{time_str}&{random_str}"
 
     cipher_aes = AES.new(key.encode(), AES.MODE_CBC, iv.encode())
 

--- a/bimmer_connected/vehicle/location.py
+++ b/bimmer_connected/vehicle/location.py
@@ -77,8 +77,7 @@ class VehicleLocation(VehicleDataBase):
             _LOGGER.error("Error retrieving vehicle position. %s: %s", error["title"], error["description"])
         else:
             pos = remote_service_dict["positionData"]["position"]
-            pos["timestamp"] = datetime.datetime.utcnow()
-            pos["timestamp"] = pos["timestamp"].replace(tzinfo=datetime.timezone.utc)
+            pos["timestamp"] = datetime.datetime.now(tz=datetime.timezone.utc)
 
             self.remote_service_position = pos
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx
 pycryptodome>=3.4
 pyjwt>=2.1.0
+importlib-metadata;python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 keywords =
     BMW
     Connected Drive
@@ -35,6 +36,6 @@ console_scripts =
     bimmerconnected = bimmer_connected.cli:main
 
 [options.package_data]
-bimmer_connected = 
+bimmer_connected =
     py.typed
     bimmer_connected/tests/responses/*

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(
         "httpx",
         "pycryptodome>=3.4",
         "pyjwt>=2.1.0",
+        "importlib-metadata;python_version<'3.8'",
     ],
 )


### PR DESCRIPTION
## Proposed change
- Add Python 3.12 as test environment for Github Actions
- Add classifier for Python 3.12
- Fix deprecations
  - Replace `pkg_resources` with `importlib.metadata` / `importlib_metadata` (for < 3.8)
  - Replace `datetime.utcnow()` with `datetime.now(tz=timezone.utc)`
  - Replace `datetime.utcfromtimestamp(...)` with `datetime.fromtimestamp(..., tz=timezone.utc)`

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
