### PR TITLE
Add headunit data class also exposing current vehicle software version

### DIFF
--- a/bimmer_connected/tests/test_vehicle.py
+++ b/bimmer_connected/tests/test_vehicle.py
@@ -280,3 +280,22 @@ def test_gpsposition():
     assert pos == (1, 2)
     assert pos != "(1, 2)"
     assert pos[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_headunit_data(caplog, bmw_fixture: respx.Router):
+    """Test if the parsing of headunit is working."""
+
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_I20).headunit
+
+    assert status.idrive_version == "ID8"
+    assert status.headunit_type == "MGU"
+    assert status.software_version == "07/2021.00"
+
+    status = (await prepare_account_with_vehicles()).get_vehicle(VIN_F31).headunit
+
+    assert status.idrive_version == "ID4"
+    assert status.headunit_type == "NBT"
+    assert status.software_version == "11/2013.02"
+
+    assert len(get_deprecation_warning_count(caplog)) == 0

--- a/bimmer_connected/vehicle/reports.py
+++ b/bimmer_connected/vehicle/reports.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from bimmer_connected.const import ATTR_STATE
+from bimmer_connected.const import ATTR_ATTRIBUTES, ATTR_STATE
 from bimmer_connected.models import StrEnum, ValueWithUnit, VehicleDataBase
 from bimmer_connected.utils import parse_datetime
 
@@ -38,7 +38,7 @@ class ConditionBasedService:
         dateTime: Optional[str] = None,
         mileage: Optional[int] = None,
         is_metric: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Parse a condition based service entry from the API format to `ConditionBasedService`."""
         due_distance = ValueWithUnit(mileage, "km" if is_metric else "mi") if mileage else ValueWithUnit(None, None)
@@ -115,5 +115,37 @@ class CheckControlMessageReport(VehicleDataBase):
             messages = vehicle_data[ATTR_STATE]["checkControlMessages"]
             retval["messages"] = [CheckControlMessage.from_api_entry(**m) for m in messages if m["severity"] != "OK"]
             retval["has_check_control_messages"] = len([m for m in retval["messages"] if m.state != "LOW"]) > 0
+
+        return retval
+
+
+@dataclass
+class Headunit(VehicleDataBase):
+    """Parse and summarizes headunit hard/software versions."""
+
+    idrive_version: str = ""
+    """IDRIVE generation."""
+
+    headunit_type: str = ""
+    """Type of headunit."""
+
+    software_version: str = ""
+    """Current software revision of vehicle"""
+
+    @classmethod
+    def _parse_vehicle_data(cls, vehicle_data: Dict) -> Optional[Dict]:
+        """Parse headunit hard/software."""
+        retval: Dict[str, Any] = {}
+
+        if ATTR_ATTRIBUTES in vehicle_data and "softwareVersionCurrent" in vehicle_data[ATTR_ATTRIBUTES]:
+            retval["idrive_version"] = vehicle_data[ATTR_ATTRIBUTES]["hmiVersion"]
+            retval["headunit_type"] = vehicle_data[ATTR_ATTRIBUTES]["headUnitType"]
+
+            istep = vehicle_data[ATTR_ATTRIBUTES]["softwareVersionCurrent"]["iStep"]
+            month = vehicle_data[ATTR_ATTRIBUTES]["softwareVersionCurrent"]["puStep"]["month"]
+            year = vehicle_data[ATTR_ATTRIBUTES]["softwareVersionCurrent"]["puStep"]["year"]
+            model_year = vehicle_data[ATTR_ATTRIBUTES]["year"]
+
+            retval["software_version"] = f"{month:02d}/{str(model_year)[:2]}{year:02d}.{str(istep)[1:]}"
 
         return retval

--- a/bimmer_connected/vehicle/vehicle.py
+++ b/bimmer_connected/vehicle/vehicle.py
@@ -21,7 +21,7 @@ from bimmer_connected.vehicle.doors_windows import DoorsAndWindows
 from bimmer_connected.vehicle.fuel_and_battery import FuelAndBattery
 from bimmer_connected.vehicle.location import VehicleLocation
 from bimmer_connected.vehicle.remote_services import RemoteServices
-from bimmer_connected.vehicle.reports import CheckControlMessageReport, ConditionBasedServiceReport
+from bimmer_connected.vehicle.reports import CheckControlMessageReport, ConditionBasedServiceReport, Headunit
 from bimmer_connected.vehicle.tires import Tires
 
 if TYPE_CHECKING:
@@ -84,6 +84,7 @@ class MyBMWVehicle:
         self.vehicle_location: VehicleLocation = VehicleLocation(account_region=account.region)
         self.doors_and_windows: DoorsAndWindows = DoorsAndWindows()
         self.condition_based_services: ConditionBasedServiceReport = ConditionBasedServiceReport()
+        self.headunit: Headunit = Headunit()
         self.check_control_messages: CheckControlMessageReport = CheckControlMessageReport()
         self.climate: Climate = Climate(account_timezone=account.timezone)
         self.charging_profile: Optional[ChargingProfile] = None
@@ -108,6 +109,7 @@ class MyBMWVehicle:
             (DoorsAndWindows, "doors_and_windows"),
             (ConditionBasedServiceReport, "condition_based_services"),
             (CheckControlMessageReport, "check_control_messages"),
+            (Headunit, "headunit"),
             (Climate, "climate"),
             (ChargingProfile, "charging_profile"),
             (Tires, "tires"),


### PR DESCRIPTION
## Proposed change
This enhancement adds headunit information like ID Drive generation and its current software revision.
Only vehicle data that also exists on older vehicles was used.

```Headunit(idrive_version='ID8', headunit_type='MGU', software_version='07/2023.35')```

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
