### PR TITLE
Require Pillow only in extra [china]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,9 @@ using :code:`pip3 install --upgrade bimmer_connected`.
 Alternatively, clone the project and execute :code:`pip install -e .` to install the current 
 :code:`master` branch.
 
+.. note::
+    If you want to connect to a **chinese** server, you need to install the :code:`[china]` extra, e.g. :code:`pip3 install --upgrade bimmer_connected[china]`.
+
 Usage
 =====
 While this library is mainly written to be included in `Home Assistant <https://www.home-assistant.io/integrations/bmw_connected_drive/>`_, it can be use on its own.

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -22,6 +22,7 @@ from bimmer_connected.api.utils import (
     get_capture_position,
     get_correlation_id,
     handle_httpstatuserror,
+    try_import_pillow_image,
 )
 from bimmer_connected.const import (
     AUTH_CHINA_CAPTCHA_CHECK_URL,
@@ -266,6 +267,10 @@ class MyBMWAuthentication(httpx.Auth):
     async def _login_china(self):
         async with MyBMWLoginClient(region=self.region) as client:
             _LOGGER.debug("Authenticating with MyBMW flow for China.")
+
+            # While PIL.Image is only needed in `get_capture_position`, we test it here to avoid
+            # unneeded requests to the server.
+            try_import_pillow_image()
 
             # Get current RSA public certificate & use it to encrypt password
             response = await client.get(

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ author = gerard33, rikroe
 summary = Library to read data from the BMW Connected Drive portal
 description_file = README.rst
 description_content_type = text/x-rst; charset=UTF-8
-python_requires = >= 3.6
+python_requires = >= 3.8
 home_page = https://github.com/bimmerconnected/bimmer_connected
 project_urls =
     Bug Tracker = https://github.com/bimmerconnected/bimmer_connected/issues

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ setup(
         "httpx",
         "pycryptodome>=3.4",
         "pyjwt>=2.1.0",
-        "Pillow"
     ],
+    extras_require={
+        "china": [
+            "Pillow",
+        ],
+    },
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Requires Pillow only for region china. This means it needs to be installed via `pip install bimmer_connected[china]`.
For chinese users, it will throw an error before the first login request against the API has been made and print a (hopefully) descriptive enough error message.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #579, fixes #582
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
