### PR TITLE
Fix non-strings in sendpoi

### DIFF
--- a/bimmer_connected/models.py
+++ b/bimmer_connected/models.py
@@ -141,10 +141,10 @@ class PointOfInterest:
     def __post_init__(self, lat, lon, street, postal_code, city, country):
         self.coordinates = GPSPosition(lat, lon)
 
-        self.locationAddress = PointOfInterestAddress(street, postal_code, city, country)
+        self.locationAddress = PointOfInterestAddress(str(street), str(postal_code), str(city), str(country))
 
         if not self.formattedAddress:
-            self.formattedAddress = ", ".join([i for i in [street, postal_code, city] if i]) or "Coordinates only"
+            self.formattedAddress = ", ".join([str(i) for i in [street, postal_code, city] if i]) or "Coordinates only"
 
 
 class ValueWithUnit(NamedTuple):

--- a/bimmer_connected/tests/test_remote_services.py
+++ b/bimmer_connected/tests/test_remote_services.py
@@ -399,3 +399,10 @@ def test_poi_parsing():
     assert poi_data.coordinates.longitude == POI_DATA["lon"]
     assert poi_data.name == "Sent with ♥ by bimmer_connected"
     assert poi_data.formattedAddress == "Somewhere over rainbow"
+
+    # Check parsing with numeric postal code
+    poi_data = PointOfInterest(lat=POI_DATA["lat"], lon=POI_DATA["lon"], postal_code=1234)
+    assert poi_data.coordinates.latitude == POI_DATA["lat"]
+    assert poi_data.coordinates.longitude == POI_DATA["lon"]
+    assert poi_data.name == "Sent with ♥ by bimmer_connected"
+    assert poi_data.locationAddress.postalCode == "1234"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes parsing of POI with numeric postcodes.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
