### PR TITLE
Update VIN regex

### DIFF
--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -23,7 +23,7 @@ from Crypto.Util.Padding import pad
 from bimmer_connected.models import AnonymizedResponse, MyBMWAPIError, MyBMWAuthError, MyBMWQuotaError
 
 UNICODE_CHARACTER_SET = string.ascii_letters + string.digits + "-._~"
-RE_VIN = re.compile(r"(?P<vin>WB[a-zA-Z0-9]{15})")
+RE_VIN = re.compile(r"(?P<vin>\b[(A-H|J-N|P|R-Z|0-9)]{17}\b)")
 ANONYMIZED_VINS: Dict[str, str] = {}
 
 

--- a/bimmer_connected/tests/test_api.py
+++ b/bimmer_connected/tests/test_api.py
@@ -47,7 +47,7 @@ def test_anonymize_data():
         "licensePlate": "secret",
         "public": "public_data",
         "a_list": [
-            {"vin": "WBA000000SECRET01"},
+            {"vin": "4US000000SECRET01"},
             {
                 "lon": 666,
                 "public": "more_public_data",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes VIN pseudonomization for vehicles not built in Germany (starting with `WB...`).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/105017
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
