### PR TITLE
Move extras_require to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,12 @@ packages =
 console_scripts =
     bimmerconnected = bimmer_connected.cli:main
 
+[options]
+install_requires =
+    httpx
+    pycryptodome>=3.4
+    pyjwt>=2.1.0
+
 [options.extras_require]
 china =
     Pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,10 @@ packages =
 console_scripts =
     bimmerconnected = bimmer_connected.cli:main
 
+[options.extras_require]
+china =
+    Pillow
+
 [options.package_data]
 bimmer_connected =
     py.typed

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,4 @@ setup(
         "pycryptodome>=3.4",
         "pyjwt>=2.1.0",
     ],
-    extras_require={
-        "china": [
-            "Pillow",
-        ],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,4 @@ from setuptools import setup
 setup(
     setup_requires=["pbr"],
     pbr=True,
-    install_requires=[
-        "httpx",
-        "pycryptodome>=3.4",
-        "pyjwt>=2.1.0",
-    ],
 )


### PR DESCRIPTION
## Proposed change
Saw a warning from pip when I tried to install `bimmer-connected[china]==0.14.6` (for Home Assistant).
```
WARNING: bimmer-connected 0.14.6 does not provide the extra 'china'
```

Turns out `pbr` has an open bug where `extras_require` inside `setup.py` are ignored. This changed moves them to `setup.cfg` so it is included in the sdist / wheel metadata.
This might fix #588.

https://bugs.launchpad.net/pbr/+bug/1931705
https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
