### PR TITLE
Update of charging sessions and statistics URLs to v2

### DIFF
--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -79,8 +79,8 @@ VEHICLE_CHARGING_START_STOP_URL = VEHICLE_CHARGING_BASE_URL + "/{service_type}"
 VEHICLE_IMAGE_URL = "/eadrax-ics/v5/presentation/vehicles/images"
 VEHICLE_POI_URL = "/eadrax-dcs/v1/send-to-car/send-to-car"
 
-VEHICLE_CHARGING_STATISTICS_URL = "/eadrax-chs/v1/charging-statistics"
-VEHICLE_CHARGING_SESSIONS_URL = "/eadrax-chs/v1/charging-sessions"
+VEHICLE_CHARGING_STATISTICS_URL = "/eadrax-chs/v2/charging-statistics"
+VEHICLE_CHARGING_SESSIONS_URL = "/eadrax-chs/v2/charging-sessions"
 
 SERVICE_CHARGING_STATISTICS_URL = "CHARGING_STATISTICS"
 SERVICE_CHARGING_SESSIONS_URL = "CHARGING_SESSIONS"


### PR DESCRIPTION
## Proposed change
The charging statistics and charging sessions URLs have changed in April 2024. Although they are not yet used in this project, this is probably helpful for other projects to be aware of.


## Type of change
- [x] Bugfix (non-breaking change as this Consts aren't used yet)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
