### PR TITLE
CLI: Store OAuth credentials in local file

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -88,7 +88,7 @@ class MyBMWAccount:
 
                     vehicle_base = dict(
                         {ATTR_ATTRIBUTES: {k: v for k, v in vehicle_profile.items() if k != "vin"}},
-                        **{"vin": vehicle_profile["vin"]}
+                        **{"vin": vehicle_profile["vin"]},
                     )
 
                     await self.add_vehicle(vehicle_base, fetched_at)
@@ -151,10 +151,15 @@ class MyBMWAccount:
         """Set the position of the observer for all vehicles."""
         self.config.observer_position = GPSPosition(latitude=latitude, longitude=longitude)
 
-    def set_refresh_token(self, refresh_token: str, gcid: Optional[str] = None) -> None:
-        """Overwrite the current value of the MyBMW refresh token and GCID (if available)."""
+    def set_refresh_token(
+        self, refresh_token: str, gcid: Optional[str] = None, access_token: Optional[str] = None
+    ) -> None:
+        """Overwrite the current value of the MyBMW tokens and GCID (if available)."""
         self.config.authentication.refresh_token = refresh_token
-        self.config.authentication.gcid = gcid
+        if gcid:
+            self.config.authentication.gcid = gcid
+        if access_token:
+            self.config.authentication.access_token = access_token
 
     @staticmethod
     def get_stored_responses() -> List[AnonymizedResponse]:

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -137,11 +137,11 @@ class MyBMWAuthentication(httpx.Auth):
             if not token_data:
                 token_data = await self._login_china()
             token_data["expires_at"] = token_data["expires_at"] - EXPIRES_AT_OFFSET
-            self.gcid = token_data["gcid"]
 
         self.access_token = token_data["access_token"]
         self.expires_at = token_data["expires_at"]
         self.refresh_token = token_data["refresh_token"]
+        self.gcid = token_data["gcid"]
 
     async def _login_row_na(self):
         """Login to Rest of World and North America."""
@@ -227,6 +227,7 @@ class MyBMWAuthentication(httpx.Auth):
             "access_token": response_json["access_token"],
             "expires_at": expires_at,
             "refresh_token": response_json["refresh_token"],
+            "gcid": response_json["gcid"],
         }
 
     async def _refresh_token_row_na(self):
@@ -271,6 +272,7 @@ class MyBMWAuthentication(httpx.Auth):
             "access_token": response_json["access_token"],
             "expires_at": expires_at,
             "refresh_token": response_json["refresh_token"],
+            "gcid": response_json["gcid"],
         }
 
     async def _login_china(self):

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -330,7 +330,7 @@ def main():
     if args.lat and args.lng:
         account.set_observer_position(args.lat, args.lng)
 
-    if not args.oauth_store.is_file():
+    if args.oauth_store.is_dir():
         args.oauth_store = args.oauth_store / ".bimmer_connected.json"
 
     if args.oauth_store.exists():

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -23,11 +23,11 @@ TEXT_VIN = "Vehicle Identification Number"
 
 def main_parser() -> argparse.ArgumentParser:
     """Create the ArgumentParser with all relevant subparsers."""
-    parser = argparse.ArgumentParser(description="A simple executable to use and test the library.")
+    parser = argparse.ArgumentParser(description="Connect to MyBMW/MINI API and interact with your vehicle.")
     parser.add_argument("--debug", help="Print debug logs.", action="store_true")
     parser.add_argument(
         "--oauth-store",
-        help="Path to the OAuth2 storage file.",
+        help="Path to the OAuth2 storage file. Defaults to $HOME/.bimmer_connected.json.",
         nargs="?",
         metavar="FILE",
         type=Path,

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -33,6 +33,7 @@ def main_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path.home() / ".bimmer_connected.json",
     )
+    parser.add_argument("--disable-oauth-store", help="Disable storing the OAuth2 tokens.", action="store_true")
 
     subparsers = parser.add_subparsers(dest="cmd")
     subparsers.required = True
@@ -342,6 +343,9 @@ def main():
     except Exception as ex:  # pylint: disable=broad-except
         sys.stderr.write(f"{type(ex).__name__}: {ex}\n")
         sys.exit(1)
+
+    if args.disable_oauth_store:
+        return
 
     args.oauth_store.parent.mkdir(parents=True, exist_ok=True)
     args.oauth_store.write_text(

--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -330,9 +330,6 @@ def main():
     if args.lat and args.lng:
         account.set_observer_position(args.lat, args.lng)
 
-    if args.oauth_store.is_dir():
-        args.oauth_store = args.oauth_store / ".bimmer_connected.json"
-
     if args.oauth_store.exists():
         try:
             account.set_refresh_token(**json.load(args.oauth_store.open()))

--- a/bimmer_connected/tests/conftest.py
+++ b/bimmer_connected/tests/conftest.py
@@ -44,6 +44,15 @@ def bmw_log_all_responses(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("bimmer_connected.account.RESPONSE_STORE", temp_store)
 
 
+@pytest.fixture
+def cli_home_dir(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
+    """Create a temporary home directory for the CLI tests."""
+    tmp_path = tmp_path_factory.mktemp("cli-home-")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    return tmp_path
+
+
 async def prepare_account_with_vehicles(region: Optional[Regions] = None):
     """Initialize account and get vehicles."""
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, region or TEST_REGION)

--- a/bimmer_connected/tests/test_account.py
+++ b/bimmer_connected/tests/test_account.py
@@ -373,11 +373,11 @@ async def test_refresh_token_getset(bmw_fixture: respx.Router):
     assert account.refresh_token is None
     await account.get_vehicles()
     assert account.refresh_token == "another_token_string"
-    assert account.gcid is None
+    assert account.gcid == "DUMMY"
 
     account.set_refresh_token("new_refresh_token")
     assert account.refresh_token == "new_refresh_token"
-    assert account.gcid is None
+    assert account.gcid == "DUMMY"
 
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, get_region_from_name("china"))
     account.set_refresh_token("new_refresh_token", "dummy_gcid")

--- a/bimmer_connected/tests/test_cli.py
+++ b/bimmer_connected/tests/test_cli.py
@@ -193,7 +193,6 @@ def test_oauth_load_credentials(cli_home_dir: Path):
     ("given", "expected"),
     [
         (".bimmer_connected.json", ".bimmer_connected.json"),
-        ("some-dir", "some-dir/.bimmer_connected.json"),
         ("other-dir/myfile.json", "other-dir/myfile.json"),
     ],
 )

--- a/bimmer_connected/tests/test_cli.py
+++ b/bimmer_connected/tests/test_cli.py
@@ -11,7 +11,7 @@ import bimmer_connected.cli
 from . import get_fingerprint_count
 
 ARGS_USER_PW_REGION = ["myuser", "mypassword", "rest_of_world"]
-FIXTURE_CLI_HELP = "A simple executable to use and test the library."
+FIXTURE_CLI_HELP = "Connect to MyBMW/MINI API and interact with your vehicle."
 
 
 def test_run_entrypoint():

--- a/bimmer_connected/tests/test_cli.py
+++ b/bimmer_connected/tests/test_cli.py
@@ -1,8 +1,9 @@
 import json
+import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -31,6 +32,7 @@ def test_run_module():
 
 
 @pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
 @pytest.mark.parametrize(
     ("vin", "expected_count"),
     [
@@ -58,6 +60,7 @@ def test_status_json_filtered(capsys: pytest.CaptureFixture, vin, expected_count
 
 
 @pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
 def test_status_json_unfiltered(capsys: pytest.CaptureFixture):
     """Test the status command JSON output filtered by VIN."""
 
@@ -71,6 +74,7 @@ def test_status_json_unfiltered(capsys: pytest.CaptureFixture):
 
 
 @pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
 @pytest.mark.parametrize(
     ("vin", "expected_count"),
     [
@@ -99,6 +103,7 @@ def test_status_filtered(capsys: pytest.CaptureFixture, vin, expected_count):
 
 
 @pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
 def test_status_unfiltered(capsys: pytest.CaptureFixture):
     """Test the status command text output filtered by VIN."""
 
@@ -112,27 +117,125 @@ def test_status_unfiltered(capsys: pytest.CaptureFixture):
 
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("bmw_log_all_responses")
-def test_fingerprint(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch):
+def test_fingerprint(capsys: pytest.CaptureFixture, cli_home_dir: Path):
     """Test the fingerprint command."""
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        tmp_path = Path(tmpdirname)
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    sys.argv = ["bimmerconnected", "fingerprint", *ARGS_USER_PW_REGION]
+    bimmer_connected.cli.main()
+    result = capsys.readouterr()
 
-        sys.argv = ["bimmerconnected", "fingerprint", *ARGS_USER_PW_REGION]
+    assert "fingerprint of the vehicles written to" in result.out
+
+    files = list((cli_home_dir / "vehicle_fingerprint").rglob("*"))
+    json_files = [f for f in files if f.suffix == ".json"]
+    txt_files = [f for f in files if f.suffix == ".txt"]
+
+    assert len(json_files) == (
+        get_fingerprint_count("vehicles")
+        + get_fingerprint_count("profiles")
+        + get_fingerprint_count("states")
+        + get_fingerprint_count("charging_settings")
+    )
+    assert len(txt_files) == 0
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
+def test_oauth_store_credentials(cli_home_dir: Path):
+    """Test storing the oauth credentials."""
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is False
+
+    sys.argv = ["bimmerconnected", "status", *ARGS_USER_PW_REGION]
+    bimmer_connected.cli.main()
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is True
+    oauth_storage = json.loads((cli_home_dir / ".bimmer_connected.json").read_text())
+
+    assert set(oauth_storage.keys()) == {"access_token", "refresh_token", "gcid"}
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
+def test_oauth_load_credentials(cli_home_dir: Path):
+    """Test loading and storing the oauth credentials."""
+
+    demo_oauth_data = {
+        "access_token": "demo_access_token",
+        "refresh_token": "demo_refresh_token",
+        "gcid": "demo_gcid",
+    }
+
+    (cli_home_dir / ".bimmer_connected.json").write_text(json.dumps(demo_oauth_data))
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is True
+
+    sys.argv = ["bimmerconnected", "status", *ARGS_USER_PW_REGION]
+
+    with mock.patch("bimmer_connected.account.MyBMWAccount.set_refresh_token") as mock_listener:
         bimmer_connected.cli.main()
-        result = capsys.readouterr()
 
-        assert "fingerprint of the vehicles written to" in result.out
+        assert mock_listener.call_count == 1
+        mock_listener.assert_called_once_with(**demo_oauth_data)
 
-        files = list(tmp_path.rglob("*"))
-        json_files = [f for f in files if f.suffix == ".json"]
-        txt_files = [f for f in files if f.suffix == ".txt"]
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is True
+    oauth_storage = json.loads((cli_home_dir / ".bimmer_connected.json").read_text())
 
-        assert len(json_files) == (
-            get_fingerprint_count("vehicles")
-            + get_fingerprint_count("profiles")
-            + get_fingerprint_count("states")
-            + get_fingerprint_count("charging_settings")
-        )
-        assert len(txt_files) == 0
+    assert set(oauth_storage.keys()) == {"access_token", "refresh_token", "gcid"}
+
+    assert oauth_storage["refresh_token"] != demo_oauth_data["refresh_token"]
+    assert oauth_storage["access_token"] != demo_oauth_data["access_token"]
+    assert oauth_storage["gcid"] != demo_oauth_data["gcid"]
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        (".bimmer_connected.json", ".bimmer_connected.json"),
+        ("some-dir", "some-dir/.bimmer_connected.json"),
+        ("other-dir/myfile.json", "other-dir/myfile.json"),
+    ],
+)
+def test_oauth_store_credentials_path(cli_home_dir: Path, tmp_path_factory: pytest.TempPathFactory, given, expected):
+    """Test storing the oauth credentials to another file."""
+
+    new_folder = tmp_path_factory.mktemp("specific-path-")
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is False
+    assert (new_folder / expected).exists() is False
+
+    sys.argv = [
+        "bimmerconnected",
+        "--oauth-store",
+        str((new_folder / given).absolute()),
+        "status",
+        *ARGS_USER_PW_REGION,
+    ]
+    bimmer_connected.cli.main()
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is False
+    assert (new_folder / expected).exists() is True
+
+    oauth_storage = json.loads((new_folder / expected).read_text())
+
+    assert set(oauth_storage.keys()) == {"access_token", "refresh_token", "gcid"}
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("cli_home_dir")
+def test_oauth_store_credentials_dev_null(cli_home_dir: Path):
+    """Test NOT storing the oauth credentials."""
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is False
+
+    sys.argv = [
+        "bimmerconnected",
+        "--oauth-store",
+        str(Path(os.devnull)),
+        "status",
+        *ARGS_USER_PW_REGION,
+    ]
+    bimmer_connected.cli.main()
+
+    assert (cli_home_dir / ".bimmer_connected.json").exists() is False

--- a/bimmer_connected/tests/test_cli.py
+++ b/bimmer_connected/tests/test_cli.py
@@ -1,5 +1,4 @@
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -190,51 +189,45 @@ def test_oauth_load_credentials(cli_home_dir: Path):
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("cli_home_dir")
 @pytest.mark.parametrize(
-    ("given", "expected"),
+    ("filepath"),
     [
-        (".bimmer_connected.json", ".bimmer_connected.json"),
-        ("other-dir/myfile.json", "other-dir/myfile.json"),
+        (".bimmer_connected.json"),
+        ("other-dir/myfile.json"),
     ],
 )
-def test_oauth_store_credentials_path(cli_home_dir: Path, tmp_path_factory: pytest.TempPathFactory, given, expected):
+def test_oauth_store_credentials_path(cli_home_dir: Path, tmp_path_factory: pytest.TempPathFactory, filepath: str):
     """Test storing the oauth credentials to another file."""
 
     new_folder = tmp_path_factory.mktemp("specific-path-")
 
     assert (cli_home_dir / ".bimmer_connected.json").exists() is False
-    assert (new_folder / expected).exists() is False
+    assert (new_folder / filepath).exists() is False
 
     sys.argv = [
         "bimmerconnected",
         "--oauth-store",
-        str((new_folder / given).absolute()),
+        str((new_folder / filepath).absolute()),
         "status",
         *ARGS_USER_PW_REGION,
     ]
     bimmer_connected.cli.main()
 
     assert (cli_home_dir / ".bimmer_connected.json").exists() is False
-    assert (new_folder / expected).exists() is True
+    assert (new_folder / filepath).exists() is True
 
-    oauth_storage = json.loads((new_folder / expected).read_text())
+    oauth_storage = json.loads((new_folder / filepath).read_text())
 
     assert set(oauth_storage.keys()) == {"access_token", "refresh_token", "gcid"}
 
 
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("cli_home_dir")
-def test_oauth_store_credentials_dev_null(cli_home_dir: Path):
+def test_oauth_store_credentials_disabled(cli_home_dir: Path):
     """Test NOT storing the oauth credentials."""
 
     assert (cli_home_dir / ".bimmer_connected.json").exists() is False
 
-    sys.argv = [
-        "bimmerconnected",
-        "--oauth-store",
-        str(Path(os.devnull)),
-        "status",
-        *ARGS_USER_PW_REGION,
-    ]
+    sys.argv = ["bimmerconnected", "--disable-oauth-store", "status", *ARGS_USER_PW_REGION]
     bimmer_connected.cli.main()
 
     assert (cli_home_dir / ".bimmer_connected.json").exists() is False


### PR DESCRIPTION
<!--
  Thanks for your contribution to bimmer_connected!
-->
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Every CLI command now stores the API credentials in a file for reuse in later calls. By default, data is stored to `~/.bimmer_connected.json` (Mac and Linux) or `C:\Users\username\.bimmer_connected.json` (Windows). The file location can be changed using the `--oauth-store` parameter.
If you don't want the data stored, use the `--disable-oauth-store` parameter.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Store OAuth2 tokens from API for commandline calls so everybody not using Home Assistant does not have to go through a full reauthentication flow on every CLI command.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
