### PR TITLE
Ignore check for vehicle finder remote service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.5.6
     hooks:
       - id: ruff
         args:
           - --fix
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         args:
@@ -24,7 +24,7 @@ repos:
         exclude_types: [csv, json]
         exclude: ^test/responses/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.11.1
     hooks: 
       - id: mypy
         name: mypy

--- a/bimmer_connected/tests/test_remote_services.py
+++ b/bimmer_connected/tests/test_remote_services.py
@@ -256,10 +256,16 @@ async def test_vehicles_without_enabled_services(bmw_fixture: respx.Router):
     vehicle.update_state({"capabilities": {}})
 
     for service in ALL_SERVICES.values():
-        with pytest.raises(ValueError):
+        # Vehicle finder always works, even if API capabilities say different
+        if service["call"] == "trigger_remote_vehicle_finder":
             await getattr(vehicle.remote_services, service["call"])(  # type: ignore[call-overload]
                 *service.get("args", []), **service.get("kwargs", {})
             )
+        else:
+            with pytest.raises(ValueError):
+                await getattr(vehicle.remote_services, service["call"])(  # type: ignore[call-overload]
+                    *service.get("args", []), **service.get("kwargs", {})
+                )
 
 
 @pytest.mark.asyncio

--- a/bimmer_connected/vehicle/remote_services.py
+++ b/bimmer_connected/vehicle/remote_services.py
@@ -313,8 +313,9 @@ class RemoteServices:
 
     async def trigger_remote_vehicle_finder(self) -> RemoteServiceStatus:
         """Trigger the vehicle finder."""
-        if not self._vehicle.is_vehicle_tracking_enabled:
-            raise ValueError(f"Vehicle does not support remote service '{Services.VEHICLE_FINDER.value}'.")
+        # Even if the API reports this as False, calling the service still works
+        # if not self._vehicle.is_vehicle_tracking_enabled:
+        #     raise ValueError(f"Vehicle does not support remote service '{Services.VEHICLE_FINDER.value}'.")
 
         status = await self.trigger_remote_service(Services.VEHICLE_FINDER)
         result = await self._get_event_position(status.event_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't check if `vehicleFinder` is active before triggering the remote service.
On older cars, this capability is returned as `false` but vehicle finder still works.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #642 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
