### PR TITLE
Always raise MyBMWAuthError during login

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.2
     hooks:
       - id: ruff
         args:

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -117,7 +117,7 @@ class MyBMWAuthentication(httpx.Auth):
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as ex:
-            await handle_httpstatuserror(ex, log_handler=_LOGGER)
+            await handle_httpstatuserror(ex, module="AUTH", log_handler=_LOGGER)
 
     async def login(self) -> None:
         """Get a valid OAuth token."""
@@ -390,7 +390,7 @@ class MyBMWLoginClient(httpx.AsyncClient):
                 try:
                     response.raise_for_status()
                 except httpx.HTTPStatusError as ex:
-                    await handle_httpstatuserror(ex, log_handler=_LOGGER)
+                    await handle_httpstatuserror(ex, module="AUTH", log_handler=_LOGGER)
 
         kwargs["event_hooks"]["response"].append(raise_for_status_event_handler)
 
@@ -420,7 +420,7 @@ class MyBMWLoginRetry(httpx.Auth):
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as ex:
-                await handle_httpstatuserror(ex, log_handler=_LOGGER)
+                await handle_httpstatuserror(ex, module="AUTH", log_handler=_LOGGER)
 
 
 def get_retry_wait_time(response: httpx.Response) -> int:

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -117,7 +117,7 @@ class MyBMWAuthentication(httpx.Auth):
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as ex:
-            await handle_httpstatuserror(ex, module="AUTH", log_handler=_LOGGER)
+            await handle_httpstatuserror(ex, module="API", log_handler=_LOGGER)
 
     async def login(self) -> None:
         """Get a valid OAuth token."""

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -65,11 +65,12 @@ async def handle_httpstatuserror(
     _ex_to_raise = MyBMWAPIError
 
     # HTTP status code is 401 or 403, raise MyBMWAuthError instead
-    if ex.response.status_code in [401, 403]:
+    # Always raise MyBMWAuthError as final when logging in (e.g. HTTP 429 should still be AuthError)
+    if ex.response.status_code in [401, 403] or module == "AUTH":
         _ex_to_raise = MyBMWAuthError
 
     # Quota errors can either be 429 Too Many Requests or 403 Quota Exceeded (instead of 401 Forbidden)
-    if ex.response.status_code == 429 or (ex.response.status_code == 403 and "quota" in ex.response.text.lower()):
+    elif ex.response.status_code == 429 or (ex.response.status_code == 403 and "quota" in ex.response.text.lower()):
         _ex_to_raise = MyBMWQuotaError
 
     try:

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -64,14 +64,16 @@ async def handle_httpstatuserror(
     # By default we will raise a MyBMWAPIError
     _ex_to_raise = MyBMWAPIError
 
+    # Quota errors can either be 429 Too Many Requests or 403 Quota Exceeded (instead of 401 Forbidden)
+    if (
+        ex.response.status_code == 429 or (ex.response.status_code == 403 and "quota" in ex.response.text.lower())
+    ) and module != "AUTH":
+        _ex_to_raise = MyBMWQuotaError
+
     # HTTP status code is 401 or 403, raise MyBMWAuthError instead
     # Always raise MyBMWAuthError as final when logging in (e.g. HTTP 429 should still be AuthError)
-    if ex.response.status_code in [401, 403] or module == "AUTH":
+    elif ex.response.status_code in [401, 403] or module == "AUTH":
         _ex_to_raise = MyBMWAuthError
-
-    # Quota errors can either be 429 Too Many Requests or 403 Quota Exceeded (instead of 401 Forbidden)
-    elif ex.response.status_code == 429 or (ex.response.status_code == 403 and "quota" in ex.response.text.lower()):
-        _ex_to_raise = MyBMWQuotaError
 
     try:
         # Try parsing the known BMW API error JSON

--- a/bimmer_connected/tests/test_account.py
+++ b/bimmer_connected/tests/test_account.py
@@ -448,8 +448,8 @@ async def test_429_retry_ok_authenticate(caplog, bmw_fixture: respx.Router):
         side_effect=[
             httpx.Response(429, json=json_429),
             httpx.Response(429, json=json_429),
-            MyBMWMockRouter.authenticate_sideeffect,
-            MyBMWMockRouter.authenticate_sideeffect,
+            MyBMWMockRouter.authenticate_sideeffect,  # type: ignore[list-item]
+            MyBMWMockRouter.authenticate_sideeffect,  # type: ignore[list-item]
         ]
     )
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Always raise `MyBMWAuthError` when a HTTP error occurs during authentication.

This should solve retry loops due to quota issues like [here](https://github.com/home-assistant/core/issues/124464#issuecomment-2306719550) and trigger the HA reauthentication flow (stopping retries).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/124464
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.
