### PR TITLE
Allow passing external SSL context

### DIFF
--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -25,6 +25,7 @@ class MyBMWClientConfiguration:
     authentication: MyBMWAuthentication
     log_responses: Optional[bool] = False
     observer_position: Optional[GPSPosition] = None
+    verify: httpx._types.VerifyTypes = True
 
     def set_log_responses(self, log_responses: bool) -> None:
         """Set if responses are logged and clear response store."""
@@ -44,6 +45,10 @@ class MyBMWClient(httpx.AsyncClient):
 
         # Increase timeout
         kwargs["timeout"] = httpx.Timeout(HTTPX_TIMEOUT)
+
+        # Use external SSL context stored in MyBMWClientConfiguration. Required in Home Assistant due to event loop
+        # blocking when httpx loads SSL certificates from disk. If not given, uses httpx defaults.
+        kwargs["verify"] = self.config.verify
 
         # Set default values
         kwargs["base_url"] = kwargs.get("base_url") or get_server_url(config.authentication.region)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows passing in an external `httpx.VerifyType` (`Union[str, bool, ssl.SSLContext]`) via the `MyBMWAccount` constructor.
This is required to stop httpx from loading SSL certificates from disk when initializing a client, as this creates warnings since 2024.9 beta.
> ```
> 2024-09-01 11:35:33.553 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to load_verify_locations with args (<ssl.SSLContext object at 0x7f507d8c46d0>,) inside the event loop by integration 'bmw_connected_drive' at homeassistant/components/bmw_connected_drive/coordinator.py, line 61: await self.account.get_vehicles() (offender: /home/richard/home-assistant-core/venv/lib/python3.12/site-packages/httpx/_config.py, line 147: context.load_verify_locations(cafile=cafile)), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+bmw_connected_drive%22
> For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_verify_locations
> ```

We're unable to use the [HA helper function](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs) due to too many adjustments to our client.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/124942
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] ~~Tests have been added to verify that the new code works.~~ No idea how to test this inside our lib.
