### PR TITLE
Fix embedded python datetime parsing

### DIFF
--- a/bimmer_connected/utils.py
+++ b/bimmer_connected/utils.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import pathlib
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -36,8 +37,13 @@ def parse_datetime(date_str: str) -> Optional[datetime.datetime]:
     date_formats = ["%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"]
     for date_format in date_formats:
         try:
-            parsed = datetime.datetime.strptime(date_str, date_format)
-            parsed = parsed.replace(microsecond=0)
+            # Parse datetimes using `time.strptime` to allow running in some embedded python interpreters.
+            # Only fixed in >=3.12: https://github.com/python/cpython/issues/71587
+            time_struct = time.strptime(date_str, date_format)
+            parsed = datetime.datetime(*(time_struct[0:6]))
+            if time_struct.tm_gmtoff and time_struct.tm_gmtoff != 0:
+                parsed = parsed - datetime.timedelta(seconds=time_struct.tm_gmtoff)
+            parsed = parsed.replace(tzinfo=datetime.timezone.utc)
             return parsed
         except ValueError:
             pass


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow running on some embedded Pythons again. cpython issue is only fixed in Python>=3.12.

This partly reverts commit 91c26e800133a33945caa620f7ea1ac1fd630f5d


## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #692 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
