### PR TITLE
Added Lock and Unlock commands to the CLI

### DIFF
--- a/bimmer_connected/cli.py
+++ b/bimmer_connected/cli.py
@@ -57,6 +57,16 @@ def main_parser() -> argparse.ArgumentParser:
     _add_position_arguments(fingerprint_parser)
     fingerprint_parser.set_defaults(func=fingerprint)
 
+    lock_parser = subparsers.add_parser("lock", description="Lock the doors of the vehicle")
+    _add_default_arguments(lock_parser)
+    lock_parser.add_argument("vin", help=TEXT_VIN)
+    lock_parser.set_defaults(func=door_lock)
+
+    unlock_parser = subparsers.add_parser("unlock", description="Unlock the doors of the vehicle")
+    _add_default_arguments(unlock_parser)
+    unlock_parser.add_argument("vin", help=TEXT_VIN)
+    unlock_parser.set_defaults(func=door_unlock)
+
     flash_parser = subparsers.add_parser("lightflash", description="Flash the vehicle lights.")
     _add_default_arguments(flash_parser)
     flash_parser.add_argument("vin", help=TEXT_VIN)
@@ -184,6 +194,22 @@ async def fingerprint(account: MyBMWAccount, args) -> None:
 
     log_response_store_to_file(account.get_stored_responses(), time_dir)
     print(f"fingerprint of the vehicles written to {time_dir}")
+
+
+async def door_lock(account: MyBMWAccount, args) -> None:
+    """Trigger the vehicle to lock its doors."""
+    await account.get_vehicles()
+    vehicle = get_vehicle_or_return(account, args.vin)
+    status = await vehicle.remote_services.trigger_remote_door_lock()
+    print(status.state)
+
+
+async def door_unlock(account: MyBMWAccount, args) -> None:
+    """Trigger the vehicle to unlock its doors."""
+    await account.get_vehicles()
+    vehicle = get_vehicle_or_return(account, args.vin)
+    status = await vehicle.remote_services.trigger_remote_door_unlock()
+    print(status.state)
 
 
 async def light_flash(account: MyBMWAccount, args) -> None:


### PR DESCRIPTION
## Proposed change
Added the ability to remotely lock or unlock the doors of the vehicle with the cli


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Uses vehicle.remote_services.trigger_remote_door_lock() for triggering the remote action
- Has required argument "vin" similiar to the lightflash or horn command
- Vehicle has to have doorLock and doorUnlock as remote capabilities

## Checklist
- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works.
