### PR TITLE
Added simple generic x-user-agent to prevent from being blocked ("quota")

### DIFF
--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -22,9 +22,9 @@ from bimmer_connected.api.utils import (
     generate_token,
     get_capture_position,
     get_correlation_id,
+    get_x_user_agent_buildstring,
     handle_httpstatuserror,
     try_import_pillow_image,
-    get_x_user_agent_buildstring,
 )
 from bimmer_connected.const import (
     AUTH_CHINA_CAPTCHA_CHECK_URL,

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -221,7 +221,9 @@ class MyBMWAuthentication(httpx.Auth):
                     "interaction-id": uuid4(),
                     "client-version": X_USER_AGENT.format(
                         build_string=get_x_user_agent_buildstring(),
-                        brand="bmw", app_version=get_app_version(self.region), region=self.region.value
+                        brand="bmw",
+                        app_version=get_app_version(self.region),
+                        region=self.region.value,
                     ),
                 },
                 data=dict(oauth_base_values, **{"authorization": authorization}),
@@ -400,7 +402,7 @@ class MyBMWLoginClient(httpx.AsyncClient):
                 build_string=get_x_user_agent_buildstring(),
                 brand="bmw",
                 app_version=get_app_version(region),
-                region=region.value
+                region=region.value,
             ),
         }
 

--- a/bimmer_connected/api/authentication.py
+++ b/bimmer_connected/api/authentication.py
@@ -24,6 +24,7 @@ from bimmer_connected.api.utils import (
     get_correlation_id,
     handle_httpstatuserror,
     try_import_pillow_image,
+    get_x_user_agent_buildstring,
 )
 from bimmer_connected.const import (
     AUTH_CHINA_CAPTCHA_CHECK_URL,
@@ -219,6 +220,7 @@ class MyBMWAuthentication(httpx.Auth):
                 params={
                     "interaction-id": uuid4(),
                     "client-version": X_USER_AGENT.format(
+                        build_string=get_x_user_agent_buildstring(),
                         brand="bmw", app_version=get_app_version(self.region), region=self.region.value
                     ),
                 },
@@ -394,7 +396,12 @@ class MyBMWLoginClient(httpx.AsyncClient):
         kwargs["base_url"] = get_server_url(region)
         kwargs["headers"] = {
             "user-agent": get_user_agent(region),
-            "x-user-agent": X_USER_AGENT.format(brand="bmw", app_version=get_app_version(region), region=region.value),
+            "x-user-agent": X_USER_AGENT.format(
+                build_string=get_x_user_agent_buildstring(),
+                brand="bmw",
+                app_version=get_app_version(region),
+                region=region.value
+            ),
         }
 
         # Register event hooks

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -10,7 +10,7 @@ import httpx
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.api.regions import get_app_version, get_server_url, get_user_agent
-from bimmer_connected.api.utils import anonymize_response, get_correlation_id, handle_httpstatuserror
+from bimmer_connected.api.utils import anonymize_response, get_correlation_id, handle_httpstatuserror, get_x_user_agent_buildstring
 from bimmer_connected.const import HTTPX_TIMEOUT, X_USER_AGENT, CarBrands
 from bimmer_connected.models import AnonymizedResponse, GPSPosition
 
@@ -90,6 +90,7 @@ class MyBMWClient(httpx.AsyncClient):
             "x-raw-locale": "en-US",
             "user-agent": get_user_agent(self.config.authentication.region),
             "x-user-agent": X_USER_AGENT.format(
+                build_string=get_x_user_agent_buildstring(),
                 brand=(brand or CarBrands.BMW).value,
                 app_version=get_app_version(self.config.authentication.region),
                 region=self.config.authentication.region.value,

--- a/bimmer_connected/api/client.py
+++ b/bimmer_connected/api/client.py
@@ -10,7 +10,12 @@ import httpx
 
 from bimmer_connected.api.authentication import MyBMWAuthentication
 from bimmer_connected.api.regions import get_app_version, get_server_url, get_user_agent
-from bimmer_connected.api.utils import anonymize_response, get_correlation_id, handle_httpstatuserror, get_x_user_agent_buildstring
+from bimmer_connected.api.utils import (
+    anonymize_response,
+    get_correlation_id,
+    get_x_user_agent_buildstring,
+    handle_httpstatuserror,
+)
 from bimmer_connected.const import HTTPX_TIMEOUT, X_USER_AGENT, CarBrands
 from bimmer_connected.models import AnonymizedResponse, GPSPosition
 

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -10,11 +10,11 @@ import logging
 import mimetypes
 import random
 import re
+import socket
 import string
 import uuid
 from typing import Dict, List, Optional, Union
 from uuid import uuid4
-import socket
 
 import httpx
 from Crypto.Cipher import AES
@@ -249,12 +249,15 @@ def try_import_pillow_image():
 
 def get_x_user_agent_buildstring():
     """
+    Usage uuid.getnode().
+
     On some systems (e.g., in containers, VMs, or when no network card is visible), uuid.getnode()
     cannot determine the true MAC.
 
     In this case, Python generates a random 48-bit number with the "multicast bit" set. Thus, not
     stable across reboots! But perfectly sufficient for our purposes.
     """
+
     system_uuid = f"{socket.gethostname()}-{uuid.getnode()}"
 
     # Stable hash

--- a/bimmer_connected/api/utils.py
+++ b/bimmer_connected/api/utils.py
@@ -28,6 +28,7 @@ UNICODE_CHARACTER_SET = string.ascii_letters + string.digits + "-._~"
 RE_VIN = re.compile(r"(?P<vin>[(A-H|J-N|P|R-Z|0-9)]{3}[A-Z0-9]{14})")
 ANONYMIZED_VINS: Dict[str, str] = {}
 
+
 def generate_token(length: int = 30, chars: str = UNICODE_CHARACTER_SET) -> str:
     """Generate a random token with given length and characters."""
     rand = random.SystemRandom()
@@ -79,7 +80,7 @@ async def handle_httpstatuserror(
     try:
         # Try parsing the known BMW API error JSON
         _err = ex.response.json()
-        _err_message = f'{type(ex).__name__}: {_err["error"]} - {_err.get("error_description", "")}'
+        _err_message = f"{type(ex).__name__}: {_err['error']} - {_err.get('error_description', '')}"
     except (json.JSONDecodeError, KeyError):
         # If format has changed or is not JSON
         _err_message = f"{type(ex).__name__}: {ex.response.text or str(ex)}"

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -56,7 +56,7 @@ USER_AGENTS = {
     Regions.REST_OF_WORLD: "Dart/3.3 (dart:io)",
     Regions.CHINA: "Dart/3.3 (dart:io)",
 }
-X_USER_AGENT = "android(AP2A.240605.024);{brand};{app_version};{region}"
+X_USER_AGENT = "android({build_string});{brand};{app_version};{region}"
 
 
 AUTH_CHINA_PUBLIC_KEY_URL = "/eadrax-coas/v1/cop/publickey"

--- a/bimmer_connected/tests/test_account.py
+++ b/bimmer_connected/tests/test_account.py
@@ -2,13 +2,13 @@
 
 import datetime
 import logging
+import re
 from pathlib import Path
 from unittest import mock
 
 import httpx
 import pytest
 import respx
-import re
 
 from bimmer_connected.account import MyBMWAccount
 from bimmer_connected.api.authentication import MyBMWAuthentication, MyBMWLoginRetry
@@ -782,10 +782,7 @@ async def test_pillow_unavailable(monkeypatch: pytest.MonkeyPatch, bmw_fixture: 
 
 
 def test_x_user_agent():
-    """
-    Test that the X-User-Agent header contains 'android' and
-    a correctly formatted buildstring (PREFIX.NUMERIC.BUILD.PATCH).
-    """
+    """Test that X-User-Agent contains 'android' and correctly formatted build-string (PREFIX.NUMERIC.BUILD.PATCH)."""
 
     # Default
     account = MyBMWAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION, hcaptcha_token=TEST_CAPTCHA)

--- a/bimmer_connected/tests/test_account.py
+++ b/bimmer_connected/tests/test_account.py
@@ -789,8 +789,6 @@ def test_x_user_agent():
     metric_client = MyBMWClient(account.config)
     header_value = metric_client.generate_default_header()["x-user-agent"]
 
-    print (header_value)
-
     assert "android" in header_value, f"'android' not found in X-User-Agent: {header_value}"
 
     pattern = r"\([A-Z0-9]{4}\.[0-9]{6}\.[A-F0-9]{3}\)"

--- a/bimmer_connected/vehicle/tires.py
+++ b/bimmer_connected/vehicle/tires.py
@@ -20,7 +20,7 @@ class TireState:
         if details:
             self.season = details.get("season")
             if details.get("manufacturingWeek"):
-                iso_string = f"20{details['manufacturingWeek'] % 100}." f"{int(details['manufacturingWeek'] / 100)}.1"
+                iso_string = f"20{details['manufacturingWeek'] % 100}.{int(details['manufacturingWeek'] / 100)}.1"
                 self.manufacturing_week = datetime.strptime(
                     iso_string,
                     "%G.%V.%u",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ignore = [
     "D107", # Missing docstring in `__init__`
     "PLR0913",  # Too many arguments in function definition
     "PLR2004",  # Magic value used in comparison
+    "PLW1641",  # Object does not implement `__hash__` method
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change, please explain that change here.
  Note: Remove this section if this PR is NOT a breaking change.
-->
n/a

## Proposed change
Added simple generic `x-user-agent` to prevent from being blocked ("quota exceeded").

BMW has apparently introduced a quota for HTTP requests, which are counted based on the HTTP header `x-user-agent`. Because this header key is hard-coded into the code and this integration is very popular, the server-side threshold may be exceeded under certain circumstances.

To prevent this, part of the `x-user-agent` is now generated dynamically. The same x-user-agent should now always be generated for each installation (server, container).

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this library)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works.

### Testcase

My home-assistant instance is running as an LXC using Proxmox Linux (ha-container with portainer). 
- first copy complete code from `bimmer_connected` on your LXC
- then mount the host volume to `/usr/local/lib/python3.13/site-packages/bimmer_connected` (in my case)
- restart container via portainer
- connect into newly startet ha-container (console) to verify successfully mounting
- go to ha and use existing bmw integration as always > Unique `x-user-agent` is now managed "under the hood".